### PR TITLE
Deduplicate task completion events between pull and push paths

### DIFF
--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -493,7 +493,14 @@ export function createTaskTool(options: TaskToolOptions): Tool {
 
   const toolDescription =
     options.description ??
-    `Delegate a task to a specialized subagent. Each subagent runs with isolated context.\n\nAvailable subagent types:\n${subagentDescriptions}`;
+    `Delegate a task to a specialized subagent. Each subagent runs with isolated context.
+
+When you call this tool multiple times in the same step (without run_in_background), the AI SDK automatically executes them in parallel via Promise.all. This is the preferred way to run concurrent tasks — no special flags needed.
+
+Use run_in_background ONLY for true fire-and-forget tasks where you want to continue the conversation immediately and be notified later when the task completes.
+
+Available subagent types:
+${subagentDescriptions}`;
 
   return tool({
     description: toolDescription,
@@ -510,7 +517,7 @@ export function createTaskTool(options: TaskToolOptions): Tool {
         .boolean()
         .optional()
         .describe(
-          "Run the task in background without blocking. Returns task ID for later retrieval via task_output tool.",
+          "Fire-and-forget: start the task in the background and continue the conversation immediately. The session will notify you when it completes. Only use this for tasks you don't need to wait on — for parallel execution, simply call the task tool multiple times in the same step (they run concurrently automatically).",
         ),
     }),
     execute: async (params) => {
@@ -837,7 +844,9 @@ export function createTaskOutputTool(options: TaskOutputToolOptions = {}): Tool 
 
   const toolDescription =
     options.description ??
-    `Inspect a background task's current state or wait for completion.
+    `Inspect a fire-and-forget background task's current state or wait for completion.
+
+This tool is for tasks started with run_in_background=true. You do NOT need this for parallel foreground tasks — those return results directly.
 
 For running tasks, shows:
 - Current status and progress
@@ -847,7 +856,7 @@ For running tasks, shows:
 For completed/failed tasks, shows the full result.
 
 Parameters:
-- task_id: The ID of the task to check (returned when task was started)
+- task_id: The ID of the task to check (returned when task was started with run_in_background)
 - block: If true, wait for task completion. If false (default), return current status immediately.
 - timeout: Maximum wait time in milliseconds (only used when block=true, default: ${defaultTimeout}ms)
 - output_lines: Number of recent output lines to show for running tasks (default: ${defaultOutputLines})`;

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for AgentSession event-driven processing and deduplication.
+ */
+
+import type { LanguageModel } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/session.js";
+import { TaskManager } from "../src/task-manager.js";
+import type { BackgroundTask } from "../src/task-store/types.js";
+import type { Agent, GenerateResult } from "../src/types.js";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createMockAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "mock-agent",
+    options: { model: {} as LanguageModel },
+    backend: {} as any,
+    state: { todos: [], files: {} },
+    ready: Promise.resolve(),
+    generate: vi.fn().mockResolvedValue({
+      status: "complete",
+      text: "Agent response",
+      steps: [],
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    } satisfies GenerateResult),
+    resume: vi.fn().mockResolvedValue({
+      status: "complete",
+      text: "Resumed response",
+      steps: [],
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    }),
+    stream: vi.fn() as any,
+    streamResponse: vi.fn() as any,
+    streamRaw: vi.fn() as any,
+    getSkills: vi.fn().mockReturnValue([]),
+    taskManager: new TaskManager(),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createCompletedTask(id: string, result = "task output"): BackgroundTask {
+  return {
+    id,
+    subagentType: "worker",
+    description: `Task ${id}`,
+    status: "completed",
+    result,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+  };
+}
+
+function createFailedTask(id: string, error = "something went wrong"): BackgroundTask {
+  return {
+    id,
+    subagentType: "worker",
+    description: `Task ${id}`,
+    status: "failed",
+    error,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+  };
+}
+
+/** Collect outputs from the session until a specific type is seen or timeout. */
+async function collectOutputs(
+  session: AgentSession,
+  opts: { until?: string; maxOutputs?: number; timeoutMs?: number } = {},
+) {
+  const { until, maxOutputs = 20, timeoutMs = 2000 } = opts;
+  const outputs: Awaited<
+    ReturnType<typeof session.run> extends AsyncGenerator<infer T> ? T : never
+  >[] = [];
+
+  const gen = session.run();
+  const deadline = Date.now() + timeoutMs;
+
+  for (let i = 0; i < maxOutputs; i++) {
+    if (Date.now() > deadline) break;
+
+    const result = await Promise.race([
+      gen.next(),
+      new Promise<{ done: true; value: undefined }>((resolve) =>
+        setTimeout(
+          () => resolve({ done: true, value: undefined }),
+          Math.max(0, deadline - Date.now()),
+        ),
+      ),
+    ]);
+
+    if (result.done) break;
+    outputs.push(result.value);
+
+    if (until && result.value.type === until) {
+      // Stop after first generation_complete
+      session.stop();
+      // Drain the stop
+      await gen.next();
+      break;
+    }
+  }
+
+  return outputs;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("AgentSession", () => {
+  let agent: Agent;
+
+  beforeEach(() => {
+    agent = createMockAgent();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Basic session flow
+  // ---------------------------------------------------------------------------
+
+  describe("basic flow", () => {
+    it("should yield waiting_for_input then process user message", async () => {
+      const session = new AgentSession({ agent });
+
+      // Send a message right away so the session doesn't block
+      setTimeout(() => session.sendMessage("Hello"), 10);
+      // Stop after first generation
+      setTimeout(() => session.stop(), 200);
+
+      const outputs = await collectOutputs(session, { until: "generation_complete" });
+
+      expect(outputs.some((o) => o.type === "waiting_for_input")).toBe(true);
+      expect(outputs.some((o) => o.type === "text_delta")).toBe(true);
+      expect(outputs.some((o) => o.type === "generation_complete")).toBe(true);
+      expect(agent.generate).toHaveBeenCalledWith(expect.objectContaining({ prompt: "Hello" }));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Task completion push delivery
+  // ---------------------------------------------------------------------------
+
+  describe("task completion push delivery", () => {
+    it("should auto-generate response when task completes", async () => {
+      const session = new AgentSession({ agent });
+      const task = createCompletedTask("task-1");
+
+      // Register task with TaskManager so it's found during dedup check
+      agent.taskManager.registerTask(task, {});
+
+      // Emit taskCompleted after session starts
+      setTimeout(() => agent.taskManager.emit("taskCompleted", task), 50);
+      setTimeout(() => session.stop(), 500);
+
+      const outputs = await collectOutputs(session, { until: "generation_complete" });
+
+      expect(agent.generate).toHaveBeenCalled();
+      const call = (agent.generate as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0].prompt).toContain("task-1");
+      expect(outputs.some((o) => o.type === "generation_complete")).toBe(true);
+    });
+
+    it("should auto-generate response when task fails", async () => {
+      const session = new AgentSession({ agent });
+      const task = createFailedTask("task-2", "timeout error");
+
+      agent.taskManager.registerTask({ ...task, status: "running" } as any, {});
+      agent.taskManager.updateTask("task-2", {
+        status: "failed",
+        error: "timeout error",
+        completedAt: new Date().toISOString(),
+      });
+
+      setTimeout(() => session.stop(), 500);
+
+      const outputs = await collectOutputs(session, { until: "generation_complete" });
+
+      expect(agent.generate).toHaveBeenCalled();
+      const call = (agent.generate as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0].prompt).toContain("task-2");
+      expect(call[0].prompt).toContain("failed");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Deduplication: task consumed via task_output
+  // ---------------------------------------------------------------------------
+
+  describe("deduplication", () => {
+    it("should skip task_completed event when task was already consumed (removed from TaskManager)", async () => {
+      const session = new AgentSession({ agent });
+      const task = createCompletedTask("task-consumed");
+
+      // Simulate: task was registered, completed, then consumed via task_output
+      // (task_output removes it from TaskManager after observation)
+      // The event is already enqueued by the time session processes it,
+      // but the task is gone from TaskManager → skip.
+
+      // Don't register the task — it's already been consumed/removed
+      // Manually enqueue the event as if TaskManager emitted it before removal
+      setTimeout(() => {
+        // Directly enqueue event (simulating what happens when task_output
+        // has already cleaned up the task from TaskManager)
+        agent.taskManager.emit("taskCompleted", task);
+      }, 50);
+
+      setTimeout(() => session.stop(), 300);
+
+      const outputs = await collectOutputs(session, { timeoutMs: 500 });
+
+      // generate should NOT have been called since the task was consumed
+      expect(agent.generate).not.toHaveBeenCalled();
+    });
+
+    it("should process task_completed when task is still in TaskManager (not consumed)", async () => {
+      const session = new AgentSession({ agent });
+      const task = createCompletedTask("task-unconsumed");
+
+      // Register the task — it hasn't been consumed by task_output
+      agent.taskManager.registerTask(task, {});
+
+      setTimeout(() => agent.taskManager.emit("taskCompleted", task), 50);
+      setTimeout(() => session.stop(), 500);
+
+      const outputs = await collectOutputs(session, { until: "generation_complete" });
+
+      // generate SHOULD have been called since task is still in TaskManager
+      expect(agent.generate).toHaveBeenCalled();
+      expect(outputs.some((o) => o.type === "generation_complete")).toBe(true);
+    });
+
+    it("should skip task_failed event when task was already consumed", async () => {
+      const session = new AgentSession({ agent });
+      const task = createFailedTask("task-fail-consumed");
+
+      // Task not in TaskManager (already consumed)
+      setTimeout(() => agent.taskManager.emit("taskFailed", task), 50);
+      setTimeout(() => session.stop(), 300);
+
+      const outputs = await collectOutputs(session, { timeoutMs: 500 });
+
+      expect(agent.generate).not.toHaveBeenCalled();
+    });
+
+    it("should handle mixed scenario: one consumed, one not", async () => {
+      const session = new AgentSession({ agent });
+
+      const consumed = createCompletedTask("task-consumed-mix");
+      const unconsumed = createCompletedTask("task-unconsumed-mix");
+
+      // Only register the unconsumed task
+      agent.taskManager.registerTask(unconsumed, {});
+
+      setTimeout(() => {
+        // Both events arrive
+        agent.taskManager.emit("taskCompleted", consumed);
+        agent.taskManager.emit("taskCompleted", unconsumed);
+      }, 50);
+
+      setTimeout(() => session.stop(), 500);
+
+      const outputs = await collectOutputs(session, { until: "generation_complete" });
+
+      // Only the unconsumed task should trigger generation
+      expect(agent.generate).toHaveBeenCalledTimes(1);
+      const call = (agent.generate as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0].prompt).toContain("task-unconsumed-mix");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cleanup after push delivery
+  // ---------------------------------------------------------------------------
+
+  describe("cleanup after push delivery", () => {
+    it("should remove task from TaskManager after push delivery", async () => {
+      const session = new AgentSession({ agent });
+      const task = createCompletedTask("task-cleanup");
+
+      // Register the task so it's found during dedup check
+      agent.taskManager.registerTask(task, {});
+      expect(agent.taskManager.getTask("task-cleanup")).toBeDefined();
+
+      setTimeout(() => agent.taskManager.emit("taskCompleted", task), 50);
+      setTimeout(() => session.stop(), 500);
+
+      await collectOutputs(session, { until: "generation_complete" });
+
+      // After push delivery, task should be removed from TaskManager
+      expect(agent.taskManager.getTask("task-cleanup")).toBeUndefined();
+    });
+
+    it("should remove failed task from TaskManager after push delivery", async () => {
+      const session = new AgentSession({ agent });
+      const failedTask = createFailedTask("task-fail-cleanup");
+
+      // Register as running, then update to failed
+      agent.taskManager.registerTask({ ...failedTask, status: "running" } as BackgroundTask, {});
+      agent.taskManager.updateTask("task-fail-cleanup", {
+        status: "failed",
+        error: "something went wrong",
+        completedAt: new Date().toISOString(),
+      });
+
+      setTimeout(() => session.stop(), 500);
+
+      await collectOutputs(session, { until: "generation_complete" });
+
+      // After push delivery, task should be removed
+      expect(agent.taskManager.getTask("task-fail-cleanup")).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // autoProcessTaskCompletions: false
+  // ---------------------------------------------------------------------------
+
+  describe("autoProcessTaskCompletions: false", () => {
+    it("should not subscribe to task events when disabled", async () => {
+      const session = new AgentSession({
+        agent,
+        autoProcessTaskCompletions: false,
+      });
+
+      const task = createCompletedTask("task-no-auto");
+      agent.taskManager.registerTask(task, {});
+
+      // Emit event — should NOT trigger processing
+      setTimeout(() => agent.taskManager.emit("taskCompleted", task), 50);
+      setTimeout(() => session.stop(), 300);
+
+      const outputs = await collectOutputs(session, { timeoutMs: 500 });
+
+      // No generation should have been triggered
+      expect(agent.generate).not.toHaveBeenCalled();
+      // Only waiting_for_input outputs expected
+      expect(outputs.every((o) => o.type === "waiting_for_input")).toBe(true);
+    });
+  });
+});

--- a/tests/task-tools.test.ts
+++ b/tests/task-tools.test.ts
@@ -6,6 +6,7 @@ import type { LanguageModel } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearCompletedTasks,
+  createTaskOutputTool,
   createTaskTool,
   getBackgroundTask,
   listBackgroundTasks,
@@ -488,6 +489,40 @@ describe("Task Tool", () => {
       expect(smartSubagent.create).toHaveBeenCalledWith(
         expect.objectContaining({ model: smartModel }),
       );
+    });
+  });
+
+  describe("Tool Descriptions", () => {
+    it("task tool description should mention parallel execution", () => {
+      const tool = createTaskTool({
+        subagents,
+        defaultModel: {} as LanguageModel,
+        parentAgent,
+      });
+
+      expect(tool.description).toContain("parallel");
+    });
+
+    it("task tool description should mention fire-and-forget for background", () => {
+      const tool = createTaskTool({
+        subagents,
+        defaultModel: {} as LanguageModel,
+        parentAgent,
+      });
+
+      expect(tool.description).toContain("fire-and-forget");
+    });
+
+    it("task_output tool description should mention fire-and-forget", () => {
+      const taskOutput = createTaskOutputTool();
+
+      expect(taskOutput.description).toContain("fire-and-forget");
+    });
+
+    it("task_output tool description should clarify it is not needed for parallel foreground tasks", () => {
+      const taskOutput = createTaskOutputTool();
+
+      expect(taskOutput.description).toContain("parallel foreground tasks");
     });
   });
 });


### PR DESCRIPTION
This pull request improves the handling and documentation of parallel and background tasks in the agent session system. It introduces deduplication logic to prevent double-processing of completed or failed tasks, ensures proper cleanup of tasks after push delivery, and updates tool descriptions for clarity. Comprehensive tests are added to verify the new behaviors.

**AgentSession event processing and deduplication:**
* Added logic in `AgentSession` to skip processing of `task_completed` and `task_failed` events if the task has already been consumed and removed from `TaskManager`, preventing duplicate responses.
* After handling a completed or failed task event, the corresponding task is now removed from `TaskManager` to ensure proper cleanup after push delivery.

**Tool descriptions and API clarity:**
* Updated the description for `createTaskTool` to clarify that calling the tool multiple times in the same step executes tasks in parallel automatically, and that `run_in_background` should only be used for true fire-and-forget tasks.
* Improved the `run_in_background` parameter description to emphasize its use case and to guide users toward preferred parallel execution.
* Enhanced the `createTaskOutputTool` description to explain its purpose for fire-and-forget background tasks and clarify that it is not needed for parallel foreground tasks. [[1]](diffhunk://#diff-53413ce590e07733de449696f3f3728d1c2524b3281fe7c02348bd52dd0046bdL840-R849) [[2]](diffhunk://#diff-53413ce590e07733de449696f3f3728d1c2524b3281fe7c02348bd52dd0046bdL850-R859)

**Testing and validation:**
* Added a new comprehensive test suite in `tests/session.test.ts` that covers AgentSession event-driven processing, deduplication logic, cleanup after push delivery, and configuration scenarios.
* Added new unit tests to verify that the updated tool descriptions contain the expected clarifications about parallel execution and fire-and-forget semantics. [[1]](diffhunk://#diff-87b8c0cdb53eb7ac15de007f3f6b66bb11cbc562c780d9368a95bef0f87a0e8bR494-R527) [[2]](diffhunk://#diff-87b8c0cdb53eb7ac15de007f3f6b66bb11cbc562c780d9368a95bef0f87a0e8bR9)When task_output consumes a completed task (removing it from TaskManager), the session now skips the queued event instead of triggering a redundant generation. Also cleans up tasks from TaskManager after push delivery to prevent memory leaks.

Updates tool descriptions to clarify that parallel execution is automatic (via Promise.all) and run_in_background is for fire-and-forget only.