### PR TITLE
Fix empty assistant message in checkpoint causing API rejection

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2290,7 +2290,7 @@ export function createAgent(options: AgentOptions): Agent {
           if (effectiveGenOptions.threadId && options.checkpointer) {
             const finalMessages: ModelMessage[] = [
               ...messages,
-              { role: "assistant" as const, content: text },
+              ...(text ? [{ role: "assistant" as const, content: text }] : []),
             ];
             await saveCheckpoint(
               effectiveGenOptions.threadId,
@@ -2321,7 +2321,7 @@ export function createAgent(options: AgentOptions): Agent {
           const hasCheckpointing = !!(effectiveGenOptions.threadId && options.checkpointer);
           let currentMessages: ModelMessage[] = hasCheckpointing
             ? []
-            : [...messages, { role: "assistant" as const, content: text }];
+            : [...messages, ...(text ? [{ role: "assistant" as const, content: text }] : [])];
 
           let followUpPrompt = await getNextTaskPrompt();
           while (followUpPrompt !== null) {
@@ -2341,7 +2341,7 @@ export function createAgent(options: AgentOptions): Agent {
               currentMessages = [
                 ...currentMessages,
                 { role: "user" as const, content: followUpPrompt },
-                { role: "assistant" as const, content: followUpText },
+                ...(followUpText ? [{ role: "assistant" as const, content: followUpText }] : []),
               ];
             }
 
@@ -2564,7 +2564,7 @@ export function createAgent(options: AgentOptions): Agent {
 
                 let currentMessages: ModelMessage[] = [
                   ...messages,
-                  { role: "assistant" as const, content: text },
+                  ...(text ? [{ role: "assistant" as const, content: text }] : []),
                 ];
 
                 let followUpPrompt = await getNextTaskPrompt();
@@ -2594,7 +2594,9 @@ export function createAgent(options: AgentOptions): Agent {
                   currentMessages = [
                     ...currentMessages,
                     { role: "user" as const, content: followUpPrompt },
-                    { role: "assistant" as const, content: followUpText },
+                    ...(followUpText
+                      ? [{ role: "assistant" as const, content: followUpText }]
+                      : []),
                   ];
 
                   // --- Post-completion bookkeeping for follow-ups ---
@@ -3066,7 +3068,7 @@ export function createAgent(options: AgentOptions): Agent {
 
                 let currentMessages: ModelMessage[] = [
                   ...messages,
-                  { role: "assistant" as const, content: text },
+                  ...(text ? [{ role: "assistant" as const, content: text }] : []),
                 ];
 
                 let followUpPrompt = await getNextTaskPrompt();
@@ -3096,7 +3098,9 @@ export function createAgent(options: AgentOptions): Agent {
                   currentMessages = [
                     ...currentMessages,
                     { role: "user" as const, content: followUpPrompt },
-                    { role: "assistant" as const, content: followUpText },
+                    ...(followUpText
+                      ? [{ role: "assistant" as const, content: followUpText }]
+                      : []),
                   ];
 
                   // --- Post-completion bookkeeping for follow-ups ---


### PR DESCRIPTION
## Summary

- When the model responds with only a tool call (no text), `response.text` is `""`. The checkpoint save unconditionally appended `{ role: "assistant", content: "" }` which the Anthropic API rejects with **"text content blocks must be non-empty"** on resume.
- Skip the assistant message when `response.text` is empty
- Applied to all four locations: cooperative interrupt path, normal completion path, and both background task follow-up paths

## Reproduction

1. Send a message that triggers a tool call with an interrupt (e.g. `ask_user`)
2. Respond to the interrupt
3. Resume fails with "text content blocks must be non-empty"

## Test plan

- [x] All 2063 existing tests pass
- [ ] Manual test: trigger `ask_user` interrupt, respond, verify resume completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)