### PR TITLE
Add default export condition to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
-      "import": "./dist/testing/index.js"
+      "import": "./dist/testing/index.js",
+      "default": "./dist/testing/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- Adds `"default"` condition to both `"."` and `"./testing"` package export entries
- Fixes compatibility with bundlers and runtimes that resolve via the `default` condition rather than `import`

## Test plan
- [x] Existing tests pass (pre-push hook ran lint + full test suite)