### PR TITLE
Replace hand-rolled YAML parser with yaml library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ajv": "^8.17.1",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.36",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "ajv": "^8.17.1"
+    "ajv": "^8.17.1",
+    "yaml": "^2.8.2"
   },
   "peerDependencies": {
     "ai": "^6.0.0",


### PR DESCRIPTION
The simple YAML parser could not handle valid YAML features like inline JSON mappings (e.g. `metadata: { "key": "value" }`), which caused marketplace skills with complex frontmatter to fail loading. Switch to the `yaml` npm package for correct YAML parsing. Metadata values are normalised to Record<string, string> for SDK compatibility.