### PR TITLE
Bump version to 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-02-22
+
 ### Fixed
 
 - `agent.stream()` now forwards reasoning stream parts (`reasoning-start`, `reasoning-delta`, `reasoning-end`) in `StreamPart`, preserving event ordering with text/tool chunks and normalizing `reasoning-delta` payloads across `text`/`delta` field variants
@@ -179,7 +181,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error types and graceful degradation utilities
 - Testing utilities via `@lleverage-ai/agent-sdk/testing`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.11...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...HEAD
+[0.0.12]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.8...v0.0.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump package version from 0.0.11 to 0.0.12
- move the unreleased agent.stream() reasoning-stream fix into a 0.0.12 release section dated 2026-02-22
- update changelog compare links for Unreleased and 0.0.12

## Validation
- bun run check (passes with one existing warning in src/task-manager.ts about an unused biome suppression)
- bun run test
