### PR TITLE
Fix negative limit handling in MCP searchTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MCPManager.searchTools()` now uses weighted lexical ranking across tool name, source, description, and input-schema fields, with fuzzy fallback for typo-tolerant matching; this improves result quality for `search_tools` + `call_tool` workflows while keeping lookup latency low via a precomputed in-memory index
 
+### Fixed
+
+- `MCPManager.searchTools()` now clamps negative `limit` values to `0`, preventing unintended `Array.slice(0, -n)` behavior and ensuring negative limits return no results
+
 ## [0.0.12] - 2026-02-22
 
 ### Fixed

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -699,9 +699,10 @@ export class MCPManager {
    */
   searchTools(query: string, limit = 10): MCPToolMetadata[] {
     this.refreshCacheIfNeeded();
+    const clampedLimit = Math.max(limit, 0);
 
-    if (!query || limit <= 0) {
-      return this.toolMetadataCache.slice(0, limit);
+    if (!query || clampedLimit === 0) {
+      return this.toolMetadataCache.slice(0, clampedLimit);
     }
 
     const normalizedQuery = normalizeText(query);
@@ -780,7 +781,7 @@ export class MCPManager {
       return a.metadata.name.localeCompare(b.metadata.name);
     });
 
-    return scored.slice(0, limit).map((entry) => entry.metadata);
+    return scored.slice(0, clampedLimit).map((entry) => entry.metadata);
   }
 
   /**

--- a/tests/mcp-manager.test.ts
+++ b/tests/mcp-manager.test.ts
@@ -101,6 +101,14 @@ describe("MCPManager", () => {
       expect(results).toHaveLength(1);
     });
 
+    it("returns empty array for negative limit", () => {
+      const noQueryResults = manager.searchTools("", -1);
+      const queryResults = manager.searchTools("github", -1);
+
+      expect(noQueryResults).toEqual([]);
+      expect(queryResults).toEqual([]);
+    });
+
     it("ranks tool-name intent higher than description-only matches", () => {
       const localManager = new MCPManager();
       localManager.registerPluginTools("payments", {


### PR DESCRIPTION
## Summary
- fix `MCPManager.searchTools()` handling for negative `limit` values by clamping to `0`
- use clamped limit consistently for early return and final ranked-slice path
- add regression test to ensure negative limits return `[]` for both empty and non-empty queries
- update changelog under `Unreleased` with a `Fixed` entry

## Validation
- bun run test tests/mcp-manager.test.ts tests/search-tools.test.ts
- bun run check
- bun run type-check
- pre-push full suite (2049 tests passed)
