### PR TITLE
Align skill context loading, checkpoint transcript persistence, and cache-stable defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `MCPManager.searchTools()` now uses weighted lexical ranking across tool name, source, description, and input-schema fields, with fuzzy fallback for typo-tolerant matching; this improves result quality for `search_tools` + `call_tool` workflows while keeping lookup latency low via a precomputed in-memory index
+- `skill` tool responses now include a structured `content` payload wrapped in `<skill_content>` XML-style tags (with instructions, tool names, optional `skill_path`, and discovered skill resource paths from metadata), enabling consistent context injection for progressive skill activation
+- Default prompt composition is now more cache-friendly by excluding the dynamic context section and todo count from default components; this keeps the base system prompt stable across turns unless users explicitly customize it
 
 ### Fixed
 
 - `MCPManager.searchTools()` now clamps negative `limit` values to `0`, preventing unintended `Array.slice(0, -n)` behavior and ensuring negative limits return no results
+- Checkpoint persistence for `generate()`, `stream()`, `streamResponse()`, and `streamDataResponse()` now prefers provider `response.messages` (assistant tool-call and tool-result transcript) over plain text-only fallbacks, preserving full tool interaction context for resume and continuation flows
+- Proxy-mode tool exposure now avoids creating `call_tool` / `search_tools` when no proxied plugin tools or external MCP servers are available, reducing unnecessary tool surface area
 
 ## [0.0.12] - 2026-02-22
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const safeAgent = createAgent({
 });
 ```
 
-**Core tools included:** `read`, `write`, `edit`, `glob`, `grep`, `todo_write`, `bash` (requires backend with `enableBash: true`), `search_tools` (when enabled)
+**Core tools included:** `read`, `write`, `edit`, `glob`, `grep`, `todo_write`, `bash` (requires backend with `enableBash: true`), `skill` (when skills are configured), `search_tools` (when enabled), `call_tool` (proxy mode only)
 
 ### Tools
 
@@ -163,6 +163,8 @@ See [Skills Documentation](./docs/skills.md) for complete details on the skills 
 ### Prompt Builder
 
 Create dynamic, context-aware system prompts from composable components. Instead of static strings, prompts automatically include tools, skills, backend capabilities, and more.
+
+The default prompt builder is cache-friendly: it avoids per-turn dynamic context sections by default so repeated generations in the same thread can reuse provider prompt caches more effectively.
 
 **Using the default builder:**
 ```typescript
@@ -354,7 +356,7 @@ export async function POST(req: Request) {
 
 - [Prompt Builder](./docs/prompt-builder.md) — Dynamic, context-aware system prompts
 - [Skills System](./docs/skills.md) — Progressive disclosure with Agent Skills spec compliance
-- [Tool Loading Strategies](./docs/tool-loading.md) — Eager, lazy, and dynamic tool loading
+- [Tool Loading Strategies](./docs/tool-loading.md) — Eager, deferred discovery, and proxy tool loading
 - [Security & Production](./docs/security.md) — Security policies, guardrails, and secrets filtering
 - [Subagents](./docs/subagents.md) — Task delegation and background tasks
 - [MCP Integration](./docs/mcp.md) — Model Context Protocol tools and servers

--- a/docs/prompt-builder.md
+++ b/docs/prompt-builder.md
@@ -27,7 +27,7 @@ The Prompt Builder system enables creating dynamic, context-aware system prompts
 - ✅ Automatically lists available tools and their descriptions
 - ✅ Includes skills and plugins when present
 - ✅ Communicates backend capabilities (bash, filesystem access)
-- ✅ Shows permission mode and context information
+- ✅ Shows permission mode information
 - ✅ Composable components with priorities
 - ✅ Conditional sections based on agent configuration
 - ✅ Easy to customize or extend
@@ -263,7 +263,11 @@ Lists available skills. Only shown when skills are present.
 
 Lists loaded plugins. Only shown when plugins are present.
 
-### 5. Capabilities Component (Priority: 60)
+### 5. Delegation Component (Priority: 75)
+
+Shows subagent delegation guidance when subagents are configured.
+
+### 6. Capabilities Component (Priority: 60)
 
 Shows what the agent can do based on backend configuration:
 
@@ -285,13 +289,9 @@ Shows what the agent can do based on backend configuration:
 }
 ```
 
-### 6. Permission Mode Component (Priority: 55)
+### 7. Permission Mode Component (Priority: 55)
 
 Explains the current permission mode. Only shown when set.
-
-### 7. Context Component (Priority: 50)
-
-Shows thread ID and message count. Only shown when available.
 
 ## Customization
 
@@ -317,7 +317,7 @@ const builder = createDefaultPromptBuilder()
 ```typescript
 const builder = createDefaultPromptBuilder()
   .unregister("identity")  // Remove default identity
-  .unregister("context");  // Don't show thread/message info
+  .unregister("permission-mode");  // Remove permission mode section
 ```
 
 ### Replacing Components
@@ -821,7 +821,7 @@ Remove unnecessary components or make them more concise:
 
 ```typescript
 const builder = createDefaultPromptBuilder()
-  .unregister("context")       // Remove if not needed
+  .unregister("delegation-instructions") // Remove if no subagents
   .unregister("permission-mode")   // Remove if static
   // Keep only essential components
 ```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -308,11 +308,39 @@ const agent = createAgent({
   model,
   tools: {
     ...coreTools,
-    load_skill: skillTool,
+    skill: skillTool,
   },
 });
 
-// Agent can now call load_skill to gain new capabilities
+// Agent can now call skill to gain new capabilities
+```
+
+The `skill` tool result includes:
+
+- `instructions`: plain instructions text
+- `newTools`: names of tools provided by the loaded skill
+- `content`: XML-style payload wrapped in `<skill_content ...>` tags for deterministic context injection
+- `skillPath`: optional absolute path for file-based skills
+
+Example `content` payload:
+
+```xml
+<skill_content name="git">
+  <instructions>Use git tools for repository operations.</instructions>
+  <tools>
+    <tool>git_status</tool>
+  </tools>
+  <skill_path>/path/to/skills/git</skill_path>
+  <skill_resources>
+    <scripts>
+      <file>/path/to/skills/git/scripts/status.sh</file>
+    </scripts>
+    <references>
+    </references>
+    <assets>
+    </assets>
+  </skill_resources>
+</skill_content>
 ```
 
 ## Agent Skills Specification Compliance
@@ -500,7 +528,7 @@ const agent = createAgent({
   skills, // That's it!
   systemPrompt: `
 You are a helpful assistant with access to specialized skills.
-Use the load_skill tool to gain new capabilities on-demand.
+Use the skill tool to gain new capabilities on-demand.
   `,
 });
 ```

--- a/src/prompt-builder/components.ts
+++ b/src/prompt-builder/components.ts
@@ -103,10 +103,6 @@ export const capabilitiesComponent: PromptComponent = {
       capabilities.push("- In-memory file operations (sandboxed)");
     }
 
-    if (ctx.state?.todos && ctx.state.todos.length > 0) {
-      capabilities.push(`- ${ctx.state.todos.length} active task(s) in the task list`);
-    }
-
     if (capabilities.length === 0) {
       return "";
     }
@@ -221,7 +217,6 @@ export const permissionModeComponent: PromptComponent = {
  * - `plugins-listing`: Loaded plugins
  * - `capabilities`: Backend capabilities
  * - `permission-mode`: Permission mode info
- * - `context`: Conversation context
  *
  * You can customize by cloning and modifying:
  *
@@ -264,6 +259,5 @@ export function createDefaultPromptBuilder(): PromptBuilder {
     pluginsComponent,
     capabilitiesComponent,
     permissionModeComponent,
-    contextComponent,
   ]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1953,7 +1953,7 @@ export interface AgentPlugin {
    * When true, this plugin's tools are accessible only via `call_tool` proxy.
    *
    * In `pluginLoading: "proxy"` mode, all plugins are deferred by default.
-   * In `pluginLoading: "eager"` (default), only plugins with `deferred: true`
+   * In `pluginLoading: "eager"`, only plugins with `deferred: true`
    * are proxied; the rest load eagerly as before.
    *
    * Deferred tools are discoverable via `search_tools` and callable via `call_tool`,

--- a/tests/prompt-builder-integration.test.ts
+++ b/tests/prompt-builder-integration.test.ts
@@ -652,7 +652,7 @@ describe("Prompt Builder Integration with Real Agents", () => {
       expect(prompt).toContain("File editing tools are auto-approved");
     });
 
-    it("should render context component with thread and messages", () => {
+    it("should not include context component by default", () => {
       const builder = createDefaultPromptBuilder();
       const prompt = builder.build({
         threadId: "thread-123",
@@ -662,9 +662,9 @@ describe("Prompt Builder Integration with Real Agents", () => {
         ],
       });
 
-      expect(prompt).toContain("# Context");
-      expect(prompt).toContain("Thread ID: thread-123");
-      expect(prompt).toContain("Conversation history: 2 message(s)");
+      expect(prompt).not.toContain("# Context");
+      expect(prompt).not.toContain("Thread ID: thread-123");
+      expect(prompt).not.toContain("Conversation history: 2 message(s)");
     });
 
     it("should order components by priority", () => {

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -396,7 +396,7 @@ describe("createDefaultPromptBuilder", () => {
     expect(names).toContain("plugins-listing");
     expect(names).toContain("capabilities");
     expect(names).toContain("permission-mode");
-    expect(names).toContain("context");
+    expect(names).not.toContain("context");
     expect(names).toContain("delegation-instructions");
   });
 
@@ -425,7 +425,7 @@ describe("createDefaultPromptBuilder", () => {
     expect(prompt).toContain("# Loaded Plugins");
     expect(prompt).toContain("# Capabilities");
     expect(prompt).toContain("# Permission Mode");
-    expect(prompt).toContain("# Context");
+    expect(prompt).not.toContain("# Context");
   });
 
   it("should be customizable via clone", () => {
@@ -494,7 +494,7 @@ describe("Integration scenarios", () => {
     expect(prompt).toContain("git");
     expect(prompt).toContain("mcp-filesystem");
     expect(prompt).toContain("Execute shell commands");
-    expect(prompt).toContain("session-abc123");
+    expect(prompt).not.toContain("session-abc123");
   });
 
   it("should respect component priorities", () => {

--- a/tests/skill-tools.test.ts
+++ b/tests/skill-tools.test.ts
@@ -333,6 +333,8 @@ describe("createSkillTool", () => {
     expect(result).toHaveProperty("skill", "git");
     expect(result).toHaveProperty("newTools");
     expect(result).toHaveProperty("instructions");
+    expect(result).toHaveProperty("content");
+    expect((result as { content: string }).content).toContain('<skill_content name="git">');
   });
 
   it("should return tool names in response", async () => {
@@ -487,10 +489,13 @@ describe("Skill Tool Integration", () => {
       success: boolean;
       instructions: string;
       message: string;
+      content: string;
     };
 
     expect(result.success).toBe(true);
     expect(result.instructions).toBe("These are the file-based skill instructions.");
     expect(result.message).toContain("instructions only, no new tools");
+    expect(result.content).toContain('<skill_content name="file-skill">');
+    expect(result.content).toContain("<skill_path>/path/to/skills/file-skill</skill_path>");
   });
 });


### PR DESCRIPTION
## Summary
- add structured XML-style `content` payload to `skill` tool responses (`<skill_content ...>`) including instructions, tool names, optional `skill_path`, and skill resource file paths
- persist structured tool-call/tool-result transcript into checkpoints by preferring provider `response.messages` across `generate()`, `stream()`, `streamResponse()`, and `streamDataResponse()` (with text fallback)
- make default prompt builder more cache-friendly by removing dynamic context/todo data from default sections
- gate `call_tool` / `search_tools` creation to only when proxy targets exist
- refresh README/docs/api reference/tool-loading/persistence/skills docs to match current SDK behavior
- update changelog under `Unreleased`

## Validation
- `bun run check`
- `bun run type-check`
- `bun run test` (executed via pre-push hook; 2051 passed, 8 skipped)

## Notes
- `pluginLoading` default remains `"eager"`; proxy behavior is opt-in via `pluginLoading: "proxy"` and/or per-plugin `deferred: true`.
