### PR TITLE
Bump version to 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-02-25
+
 ### Changed
 
 - `MCPManager.searchTools()` now uses weighted lexical ranking across tool name, source, description, and input-schema fields, with fuzzy fallback for typo-tolerant matching; this improves result quality for `search_tools` + `call_tool` workflows while keeping lookup latency low via a precomputed in-memory index
@@ -193,7 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error types and graceful degradation utilities
 - Testing utilities via `@lleverage-ai/agent-sdk/testing`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.13...HEAD
+[0.0.13]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.9...v0.0.10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump package version from `0.0.12` to `0.0.13`
- release current `Unreleased` changelog entries under `## [0.0.13] - 2026-02-25`
- update changelog compare links (`Unreleased` now compares from `v0.0.13`)

## Validation
- `bun run check`
- pre-push hook: `bun run check` + `bun run test` (2051 passed, 8 skipped)
