### PR TITLE
feat(agent-threads): add user-message accumulator handling and release alpha.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "packages/agent-threads": {
       "name": "@lleverage-ai/agent-threads",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "devDependencies": {
         "vitest": "^4.0.18",
         "zod": "^4.3.6",

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3] - 2026-02-28
+
+### Added
+
+- Accumulator reducer now handles `user-message` stream events by committing any in-progress assistant output and appending a canonical `role: "user"` message
+
 ## [0.1.0-alpha.2] - 2026-02-28
 
 ### Added
@@ -36,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ledger layer: canonical message schema, `RunManager`, accumulator, reconciliation, `FullContextBuilder`, ledger stores (`InMemoryLedgerStore`, `SQLiteLedgerStore`)
 - Subpath exports for granular imports: `./stream`, `./ledger`, `./server`, `./client`, `./stores/*`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.2...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.3...HEAD
+[0.1.0-alpha.3]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.2...agent-threads@0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.1...agent-threads@0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/lleverage-ai/agent-sdk/releases/tag/agent-threads@0.1.0-alpha.1

--- a/packages/agent-threads/package.json
+++ b/packages/agent-threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-threads",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Event transport, replay, and durable transcripts for AI agent conversations",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -105,6 +105,22 @@ function createReducer(
         break;
       }
 
+      case "user-message": {
+        commitCurrentMessage(state);
+        const p = payload as { content: string };
+        const userMsg = {
+          id: idGen(),
+          parentMessageId: state.lastMessageId,
+          role: "user" as const,
+          parts: [{ type: "text" as const, text: p.content }],
+          createdAt: new Date().toISOString(),
+          metadata: { schemaVersion: 1 },
+        };
+        state.messages.push(userMsg);
+        state.lastMessageId = userMsg.id;
+        break;
+      }
+
       case "text-delta": {
         ensureCurrentMessage(state, idGen);
         const p = payload as { delta: string };


### PR DESCRIPTION
## Summary
- add user-message case to ledger accumulator reducer
- create canonical role "user" message with parent linking
- add accumulator test coverage for user-message sequencing
- bump @lleverage-ai/agent-threads to 0.1.0-alpha.3
- update changelog and lockfile

## Verification
- bun run --filter '@lleverage-ai/agent-threads' build
- bun run --filter '@lleverage-ai/agent-threads' test
- bun run --filter '@lleverage-ai/agent-threads' type-check
- npm publish --dry-run --tag alpha
