### PR TITLE
Make context compaction protocol-aware for tool-call invariants and failure recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@lleverage-ai/agent-stream` and `@lleverage-ai/agent-ledger` have been merged into `@lleverage-ai/agent-threads` with subpath exports (`./stream`, `./ledger`, `./server`, `./client`, `./stores/*`)
 - Workspace scripts (`build`, `type-check`, `test`, `clean`) now use the simplified two-package build order (`agent-threads` → `agent-sdk`)
 - `createDefaultPromptBuilder()` now uses a goal-directed, behavior-first default prompt shape with compact capability summaries; verbose tool, skill, and plugin listings remain available as opt-in components
+- Context compaction is now protocol-aware: token budgets can reserve output headroom, retained history preserves tool-call/tool-result blocks, and repeated compaction failures open a bounded cooldown circuit instead of retrying indefinitely
 - `RecoverResult` typing is now status-narrowed to active-to-terminal transitions (`created|streaming` → `failed|cancelled`)
 - `TypedEmitter` now accepts interface-based event maps, allowing `WsClientEvents` to follow the repository `interface` convention without requiring index-signature workarounds
 - Fork finalization in both ledger stores is now non-destructive: committing a run at a fork point preserves previously committed branch messages while still superseding older runs at that fork

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ export async function POST(req: Request) {
 - [Middleware](./docs/middleware.md) — Logging, caching, retry, and guardrails
 - [Observability](./docs/observability.md) — Logging, metrics, and tracing
 - [Persistence](./docs/persistence.md) — Memory and checkpointing
-- [Context Compaction](./docs/context-compaction.md) — Automatic context management
+- [Context Compaction](./docs/context-compaction.md) — Automatic, protocol-aware context management
 - [Error Handling](./docs/errors.md) — Typed errors and recovery
 - [API Reference](./docs/api-reference.md) — Complete API documentation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -277,6 +277,10 @@ contextManager.unpinMessage(index: number): void;
 contextManager.isPinned(index: number): boolean;
 ```
 
+`TokenBudget` includes `effectiveMaxTokens`, `outputReserveTokens`, and `state` so hosts can
+surface context pressure before hard failures. `CompactionPolicy` also supports
+`outputReserveTokens`, `maxConsecutiveFailures`, and `failureCooldownMs`.
+
 ## Observability
 
 | Function | Description |

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -305,9 +305,12 @@ const contextManager = createContextManager({
 | Property | Description |
 |----------|-------------|
 | `currentTokens` | Current token count (actual or estimated) |
-| `maxTokens` | Maximum allowed tokens |
+| `maxTokens` | Raw maximum allowed tokens before any reservation |
+| `effectiveMaxTokens` | Prompt budget after subtracting reserved output headroom |
 | `usage` | Usage percentage (0-1) |
-| `remaining` | Tokens remaining |
+| `remaining` | Tokens remaining within the effective prompt budget |
+| `outputReserveTokens` | Tokens reserved for model output that reduce `effectiveMaxTokens` |
+| `state` | Context pressure state: `normal`, `warning`, or `blocking` |
 | `isActual` | `true` if based on model usage, `false` if estimated |
 
 ```typescript

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -15,6 +15,7 @@ const contextManager = createContextManager({
     hardCapThreshold: 0.95, // Force compact at 95% (safety)
     enableGrowthRatePrediction: false,
     enableErrorFallback: true, // Auto-compact on context length errors
+    outputReserveTokens: 4000, // Reserve room for the model's next reply
   },
   summarization: {
     keepMessageCount: 10, // Always keep last 10 messages
@@ -29,6 +30,22 @@ const agent = createAgent({
 });
 ```
 
+## Generic Summarization vs Protocol-Aware Compaction
+
+The context manager now treats compaction as more than "summarize old messages".
+
+- Generic summarization reduces old context into a summary message.
+- Protocol-aware compaction keeps transcript structure valid while doing that reduction.
+
+In practice, protocol-aware compaction:
+
+- reserves explicit output headroom before deciding usable prompt budget
+- preserves assistant `tool-call` messages with their matching `tool-result` messages
+- keeps multipart assistant messages intact instead of trimming through a protocol block
+- stops repeated autocompaction attempts after bounded failures and retries after cooldown
+
+Use this mode whenever the transcript includes tools, streamed assistant parts, or checkpointed sessions that will be sent back to a provider.
+
 ## Compaction Triggers
 
 The SDK supports multiple compaction triggers:
@@ -39,6 +56,7 @@ The SDK supports multiple compaction triggers:
 | Hard Cap | Safety limit — forces compaction to prevent errors | 95% |
 | Growth Rate | Predicts if next message will exceed limits | Disabled |
 | Error Fallback | Emergency compaction on context length errors | Enabled |
+| Output Reserve | Reserved prompt headroom for the next response | 0 tokens |
 
 ```typescript
 const contextManager = createContextManager({
@@ -49,9 +67,14 @@ const contextManager = createContextManager({
     hardCapThreshold: 0.9, // Force at 90%
     enableGrowthRatePrediction: true, // Enable predictive compaction
     enableErrorFallback: true, // Auto-recover from context errors
+    outputReserveTokens: 4000, // Shrink usable prompt budget by 4k tokens
   },
 });
 ```
+
+`contextManager.getBudget(messages)` now reports both the raw `maxTokens` and the effective
+prompt budget after reservation via `effectiveMaxTokens`, along with a `state` of
+`"normal" | "warning" | "blocking"`.
 
 ## Custom Compaction Policy
 
@@ -66,6 +89,9 @@ const contextManager = createContextManager({
     hardCapThreshold: 0.95,
     enableGrowthRatePrediction: false,
     enableErrorFallback: true,
+    outputReserveTokens: 4000,
+    maxConsecutiveFailures: 3,
+    failureCooldownMs: 60000,
     // Custom compaction logic
     shouldCompact: (budget, messages) => {
       // Trigger if more than 50 messages
@@ -81,6 +107,9 @@ const contextManager = createContextManager({
   },
 });
 ```
+
+The default compaction flow is transcript-aware, so retained history will expand as needed to
+keep tool-call/tool-result blocks coherent even when `keepMessageCount` would otherwise split them.
 
 ## Compaction Strategies
 

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -56,7 +56,7 @@ The SDK supports multiple compaction triggers:
 | Hard Cap | Safety limit — forces compaction to prevent errors | 95% |
 | Growth Rate | Predicts if next message will exceed limits | Disabled |
 | Error Fallback | Emergency compaction on context length errors | Enabled |
-| Output Reserve | Reserved prompt headroom for the next response | 0 tokens |
+| Output Reserve (budget adjustment) | Reduces usable prompt budget to reserve headroom for the next response | 0 tokens |
 
 ```typescript
 const contextManager = createContextManager({
@@ -75,6 +75,9 @@ const contextManager = createContextManager({
 `contextManager.getBudget(messages)` now reports both the raw `maxTokens` and the effective
 prompt budget after reservation via `effectiveMaxTokens`, along with a `state` of
 `"normal" | "warning" | "blocking"`.
+
+`outputReserveTokens` is not an independent compaction trigger. It reduces `effectiveMaxTokens`,
+which changes when the threshold and hard-cap triggers fire.
 
 ## Custom Compaction Policy
 

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -2347,6 +2347,7 @@ export function createAgent(options: AgentOptions): Agent {
           // Note: Only attempt this ONCE to avoid infinite loops
           if (
             options.contextManager?.policy.enableErrorFallback &&
+            !effectiveGenOptions._skipCompaction &&
             retryState.retryAttempt === 0 && // Only on first error, not on retry
             isContextLengthError(normalizedError)
           ) {

--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -1477,7 +1477,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
       // If nothing to compact, return unchanged
       if (oldMessages.length === 0) {
-        if (trigger === "error_fallback" || shouldCompact(messages).trigger) {
+        if (trigger === "error_fallback") {
           throw new Error("Context compaction could not reduce the transcript");
         }
 

--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -296,6 +296,11 @@ export interface TokenBudget {
   /** Maximum tokens allowed in context */
   maxTokens: number;
 
+  /**
+   * Maximum prompt tokens available after reserving output headroom.
+   */
+  effectiveMaxTokens: number;
+
   /** Current token count in context */
   currentTokens: number;
 
@@ -306,6 +311,16 @@ export interface TokenBudget {
   remaining: number;
 
   /**
+   * Tokens explicitly reserved for model output.
+   */
+  outputReserveTokens: number;
+
+  /**
+   * Current context pressure relative to warning and blocking thresholds.
+   */
+  state: CompactionPressureState;
+
+  /**
    * Whether this budget is based on actual usage from the model.
    * True if updated with real usage data, false if estimated.
    */
@@ -313,11 +328,19 @@ export interface TokenBudget {
 }
 
 /**
+ * Context pressure state derived from the effective token budget.
+ *
+ * @category Context
+ */
+export type CompactionPressureState = "normal" | "warning" | "blocking";
+
+/**
  * Creates a token budget from current usage.
  *
  * @param maxTokens - Maximum tokens allowed
  * @param currentTokens - Current token count
  * @param isActual - Whether this is based on actual model usage (default: false)
+ * @param options - Effective budget options
  * @returns A token budget object
  *
  * @category Context
@@ -326,12 +349,34 @@ export function createTokenBudget(
   maxTokens: number,
   currentTokens: number,
   isActual = false,
+  options: {
+    outputReserveTokens?: number;
+    warningThreshold?: number;
+    blockingThreshold?: number;
+  } = {},
 ): TokenBudget {
+  const outputReserveTokens = Math.max(0, options.outputReserveTokens ?? 0);
+  const effectiveMaxTokens = Math.max(1, maxTokens - outputReserveTokens);
+  const usage = currentTokens / effectiveMaxTokens;
+  const warningThreshold = options.warningThreshold ?? DEFAULT_COMPACTION_POLICY.tokenThreshold;
+  const blockingThreshold =
+    options.blockingThreshold ?? DEFAULT_COMPACTION_POLICY.hardCapThreshold;
+
+  let state: CompactionPressureState = "normal";
+  if (usage >= blockingThreshold) {
+    state = "blocking";
+  } else if (usage >= warningThreshold) {
+    state = "warning";
+  }
+
   return {
     maxTokens,
+    effectiveMaxTokens,
     currentTokens,
-    usage: currentTokens / maxTokens,
-    remaining: Math.max(0, maxTokens - currentTokens),
+    usage,
+    remaining: Math.max(0, effectiveMaxTokens - currentTokens),
+    outputReserveTokens,
+    state,
     isActual,
   };
 }
@@ -395,6 +440,25 @@ export interface CompactionPolicy {
   enableErrorFallback: boolean;
 
   /**
+   * Prompt tokens to reserve for the model's output before evaluating compaction.
+   * @defaultValue 0
+   */
+  outputReserveTokens: number;
+
+  /**
+   * Maximum consecutive compaction failures before opening the circuit.
+   * While the circuit is open, automatic compaction is skipped.
+   * @defaultValue 3
+   */
+  maxConsecutiveFailures: number;
+
+  /**
+   * Cooldown period, in milliseconds, after the compaction circuit opens.
+   * @defaultValue 60000
+   */
+  failureCooldownMs: number;
+
+  /**
    * Custom function to decide if compaction is needed.
    * If provided, overrides default policy logic.
    * @param budget - Current token budget
@@ -418,6 +482,9 @@ export const DEFAULT_COMPACTION_POLICY: CompactionPolicy = {
   hardCapThreshold: 0.95,
   enableGrowthRatePrediction: false,
   enableErrorFallback: true,
+  outputReserveTokens: 0,
+  maxConsecutiveFailures: 3,
+  failureCooldownMs: 60000,
 };
 
 // =============================================================================
@@ -1100,6 +1167,11 @@ export interface ContextManager {
   isPinned(messageIndex: number): boolean;
 }
 
+interface IndexedMessage {
+  message: ModelMessage;
+  originalIndex: number;
+}
+
 /**
  * Default prompt for generating conversation summaries.
  */
@@ -1173,8 +1245,11 @@ Format:
  * ```typescript
  * const contextManager = createContextManager({
  *   maxTokens: 100000,
- *   summarization: {
+ *   policy: {
  *     tokenThreshold: 0.75,
+ *     outputReserveTokens: 4000,
+ *   },
+ *   summarization: {
  *     keepMessageCount: 15,
  *   },
  *   onBudgetUpdate: (budget) => {
@@ -1212,6 +1287,9 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
   // Track summary tiers for tiered strategy
   let currentSummaryTier = 0;
+  let activeCompactions = 0;
+  let consecutiveCompactionFailures = 0;
+  let compactionCircuitOpenUntil: number | undefined;
 
   // Create scheduler if background compaction is enabled
   let scheduler: CompactionScheduler | undefined;
@@ -1234,15 +1312,49 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
       currentTokens = tokenCounter.countMessages(messages);
     }
 
-    const budget = createTokenBudget(maxTokens, currentTokens, isActual);
+    const budget = createTokenBudget(maxTokens, currentTokens, isActual, {
+      outputReserveTokens: policy.outputReserveTokens,
+      warningThreshold: policy.tokenThreshold,
+      blockingThreshold: policy.hardCapThreshold,
+    });
     onBudgetUpdate?.(budget);
     return budget;
+  };
+
+  const isCompactionCircuitOpen = (): boolean => {
+    if (
+      compactionCircuitOpenUntil !== undefined &&
+      Date.now() >= compactionCircuitOpenUntil
+    ) {
+      compactionCircuitOpenUntil = undefined;
+      consecutiveCompactionFailures = 0;
+    }
+
+    return compactionCircuitOpenUntil !== undefined;
+  };
+
+  const recordCompactionSuccess = (): void => {
+    consecutiveCompactionFailures = 0;
+    compactionCircuitOpenUntil = undefined;
+  };
+
+  const recordCompactionFailure = (): void => {
+    consecutiveCompactionFailures++;
+
+    if (consecutiveCompactionFailures >= policy.maxConsecutiveFailures) {
+      const cooldownMs = Math.max(0, policy.failureCooldownMs);
+      compactionCircuitOpenUntil = Date.now() + cooldownMs;
+    }
   };
 
   const shouldCompact = (
     messages: ModelMessage[],
   ): { trigger: boolean; reason?: CompactionTrigger } => {
     if (!policy.enabled) {
+      return { trigger: false };
+    }
+
+    if (isCompactionCircuitOpen()) {
       return { trigger: false };
     }
 
@@ -1274,7 +1386,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
         // If last message is significantly larger than average, predict growth
         if (lastMessageTokens > avgMessageTokens * 2) {
           const predictedNext = budget.currentTokens + lastMessageTokens;
-          const predictedUsage = predictedNext / maxTokens;
+          const predictedUsage = predictedNext / budget.effectiveMaxTokens;
 
           if (predictedUsage >= policy.tokenThreshold) {
             return { trigger: true, reason: "growth_rate" };
@@ -1291,85 +1403,135 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
     agent: Agent,
     trigger: CompactionTrigger = "token_threshold",
   ): Promise<CompactionResult> => {
-    const tokensBefore = tokenCounter.countMessages(messages);
-    const messagesBefore = messages.length;
-
-    const {
-      keepMessageCount,
-      strategy = "rollup",
-      enableStructuredSummary,
-      enableTieredSummaries,
-    } = summarizationConfig;
-
-    // Always keep system messages
-    const systemMessages = messages.filter((m) => m.role === "system");
-    const _nonSystemMessages = messages.filter((m) => m.role !== "system");
-
-    // Filter out pinned messages (keep them separate)
-    // pinnedMessages indices refer to the original messages array
-    const pinnedIndices = new Set(pinnedMessages.map((p) => p.messageIndex));
-    const pinnedMessagesArray: ModelMessage[] = [];
-    const unpinnedMessages: ModelMessage[] = [];
-
-    messages.forEach((msg, idx) => {
-      // Skip system messages (already handled)
-      if (msg.role === "system") return;
-
-      if (pinnedIndices.has(idx)) {
-        pinnedMessagesArray.push(msg);
-      } else {
-        unpinnedMessages.push(msg);
-      }
-    });
-
-    // Keep recent messages from unpinned messages
-    const recentMessages = unpinnedMessages.slice(-keepMessageCount);
-    const oldMessages = unpinnedMessages.slice(
-      0,
-      Math.max(0, unpinnedMessages.length - keepMessageCount),
-    );
-
-    // If nothing to compact, return unchanged
-    if (oldMessages.length === 0) {
-      return {
-        messagesBefore,
-        messagesAfter: messages.length,
-        tokensBefore,
-        tokensAfter: tokensBefore,
-        summary: "",
-        compactedMessages: [],
-        newMessages: messages,
-        trigger,
-        strategy,
-      };
+    if (isCompactionCircuitOpen()) {
+      throw new Error("Context compaction circuit is open after repeated failures");
     }
 
-    // Execute strategy-specific compaction
-    let summary: string;
-    let structuredSummary: StructuredSummary | undefined;
-    let summaryTier: number | undefined;
+    if (activeCompactions > 0) {
+      throw new Error("Recursive context compaction is not allowed");
+    }
 
-    if (strategy === "tiered" && enableTieredSummaries) {
-      // Tiered strategy: check if we have existing summaries to tier
-      const existingSummaries = messages.filter(
-        (m) =>
-          m.role === "assistant" &&
-          typeof m.content === "string" &&
-          m.content.includes("[Previous conversation summary]"),
+    activeCompactions++;
+
+    try {
+      const tokensBefore = tokenCounter.countMessages(messages);
+      const messagesBefore = messages.length;
+
+      const {
+        keepMessageCount,
+        keepToolResultCount,
+        strategy = "rollup",
+        enableStructuredSummary,
+        enableTieredSummaries,
+      } = summarizationConfig;
+
+      // Always keep system messages
+      const systemMessages = messages.filter((m) => m.role === "system");
+
+      const pinnedIndices = new Set(pinnedMessages.map((p) => p.messageIndex));
+      const retainedIndices = collectRetainedConversationIndices(messages, {
+        pinnedIndices,
+        keepMessageCount,
+        keepToolResultCount,
+      });
+      const retainedMessages = messages.filter(
+        (message, index) => message.role !== "system" && retainedIndices.has(index),
+      );
+      const oldMessages = messages.filter(
+        (message, index) => message.role !== "system" && !retainedIndices.has(index),
       );
 
-      if (existingSummaries.length >= (summarizationConfig.messagesPerTier ?? 5)) {
-        // Create a higher-tier summary
-        currentSummaryTier++;
-        const summariesContent = existingSummaries.map((m) => m.content).join("\n\n");
-        const tierPrompt = TIERED_SUMMARY_PROMPT.replace("{tier}", String(currentSummaryTier));
+      // If nothing to compact, return unchanged
+      if (oldMessages.length === 0) {
+        recordCompactionSuccess();
+        return {
+          messagesBefore,
+          messagesAfter: messages.length,
+          tokensBefore,
+          tokensAfter: tokensBefore,
+          summary: "",
+          compactedMessages: [],
+          newMessages: messages,
+          trigger,
+          strategy,
+        };
+      }
+
+      // Execute strategy-specific compaction
+      let summary: string;
+      let structuredSummary: StructuredSummary | undefined;
+      let summaryTier: number | undefined;
+
+      if (strategy === "tiered" && enableTieredSummaries) {
+        // Tiered strategy: check if we have existing summaries to tier
+        const existingSummaries = messages.filter(
+          (m) =>
+            m.role === "assistant" &&
+            typeof m.content === "string" &&
+            m.content.includes("[Previous conversation summary]"),
+        );
+
+        if (existingSummaries.length >= (summarizationConfig.messagesPerTier ?? 5)) {
+          // Create a higher-tier summary
+          currentSummaryTier++;
+          const summariesContent = existingSummaries.map((m) => m.content).join("\n\n");
+          const tierPrompt = TIERED_SUMMARY_PROMPT.replace("{tier}", String(currentSummaryTier));
+
+          const summaryResult = await agent.generate({
+            messages: [
+              { role: "system" as const, content: tierPrompt },
+              {
+                role: "user" as const,
+                content: `Consolidate these summaries:\n\n${summariesContent}`,
+              },
+            ],
+            maxTokens: 1000,
+            _skipCompaction: true, // Prevent recursive compaction during summary generation
+          });
+
+          summary = summaryResult.status === "complete" ? summaryResult.text : "";
+          summaryTier = currentSummaryTier;
+        } else {
+          // Create a first-tier summary
+          const contentToSummarize = formatMessagesForSummary(oldMessages);
+          const summaryPrompt = enableStructuredSummary
+            ? STRUCTURED_SUMMARY_PROMPT
+            : (summarizationConfig.summaryPrompt ?? DEFAULT_SUMMARY_PROMPT);
+
+          const summaryResult = await agent.generate({
+            messages: [
+              { role: "system" as const, content: summaryPrompt },
+              {
+                role: "user" as const,
+                content: `Please summarize this conversation history:\n\n${contentToSummarize}`,
+              },
+            ],
+            maxTokens: 1000,
+            _skipCompaction: true, // Prevent recursive compaction during summary generation
+          });
+
+          summary = summaryResult.status === "complete" ? summaryResult.text : "";
+          summaryTier = 0;
+
+          // Try to parse structured summary if enabled
+          if (enableStructuredSummary) {
+            try {
+              structuredSummary = JSON.parse(summary) as StructuredSummary;
+            } catch {
+              // If parsing fails, keep as plain text
+            }
+          }
+        }
+      } else if (strategy === "structured" || enableStructuredSummary) {
+        // Structured strategy: generate JSON with sections
+        const contentToSummarize = formatMessagesForSummary(oldMessages);
 
         const summaryResult = await agent.generate({
           messages: [
-            { role: "system" as const, content: tierPrompt },
+            { role: "system" as const, content: STRUCTURED_SUMMARY_PROMPT },
             {
               role: "user" as const,
-              content: `Consolidate these summaries:\n\n${summariesContent}`,
+              content: `Please summarize this conversation history:\n\n${contentToSummarize}`,
             },
           ],
           maxTokens: 1000,
@@ -1377,13 +1539,17 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
         });
 
         summary = summaryResult.status === "complete" ? summaryResult.text : "";
-        summaryTier = currentSummaryTier;
+
+        // Try to parse structured summary
+        try {
+          structuredSummary = JSON.parse(summary) as StructuredSummary;
+        } catch {
+          // If parsing fails, keep as plain text
+        }
       } else {
-        // Create a first-tier summary
+        // Rollup strategy (default): single summary of old messages
         const contentToSummarize = formatMessagesForSummary(oldMessages);
-        const summaryPrompt = enableStructuredSummary
-          ? STRUCTURED_SUMMARY_PROMPT
-          : (summarizationConfig.summaryPrompt ?? DEFAULT_SUMMARY_PROMPT);
+        const summaryPrompt = summarizationConfig.summaryPrompt ?? DEFAULT_SUMMARY_PROMPT;
 
         const summaryResult = await agent.generate({
           messages: [
@@ -1398,100 +1564,49 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
         });
 
         summary = summaryResult.status === "complete" ? summaryResult.text : "";
-        summaryTier = 0;
-
-        // Try to parse structured summary if enabled
-        if (enableStructuredSummary) {
-          try {
-            structuredSummary = JSON.parse(summary) as StructuredSummary;
-          } catch {
-            // If parsing fails, keep as plain text
-          }
-        }
       }
-    } else if (strategy === "structured" || enableStructuredSummary) {
-      // Structured strategy: generate JSON with sections
-      const contentToSummarize = formatMessagesForSummary(oldMessages);
 
-      const summaryResult = await agent.generate({
-        messages: [
-          { role: "system" as const, content: STRUCTURED_SUMMARY_PROMPT },
-          {
-            role: "user" as const,
-            content: `Please summarize this conversation history:\n\n${contentToSummarize}`,
-          },
-        ],
-        maxTokens: 1000,
-        _skipCompaction: true, // Prevent recursive compaction during summary generation
-      });
+      // Build new message history
+      const summaryPrefix =
+        summaryTier !== undefined
+          ? `[Previous conversation summary - Tier ${summaryTier}]`
+          : "[Previous conversation summary]";
 
-      summary = summaryResult.status === "complete" ? summaryResult.text : "";
+      const summaryMessage: ModelMessage = {
+        role: "assistant" as const,
+        content: structuredSummary
+          ? `${summaryPrefix}\n\n${formatStructuredSummary(structuredSummary)}`
+          : `${summaryPrefix}\n\n${summary}`,
+      };
 
-      // Try to parse structured summary
-      try {
-        structuredSummary = JSON.parse(summary) as StructuredSummary;
-      } catch {
-        // If parsing fails, keep as plain text
-      }
-    } else {
-      // Rollup strategy (default): single summary of old messages
-      const contentToSummarize = formatMessagesForSummary(oldMessages);
-      const summaryPrompt = summarizationConfig.summaryPrompt ?? DEFAULT_SUMMARY_PROMPT;
+      const newMessages: ModelMessage[] = [...systemMessages, summaryMessage, ...retainedMessages];
 
-      const summaryResult = await agent.generate({
-        messages: [
-          { role: "system" as const, content: summaryPrompt },
-          {
-            role: "user" as const,
-            content: `Please summarize this conversation history:\n\n${contentToSummarize}`,
-          },
-        ],
-        maxTokens: 1000,
-        _skipCompaction: true, // Prevent recursive compaction during summary generation
-      });
+      const tokensAfter = tokenCounter.countMessages(newMessages);
 
-      summary = summaryResult.status === "complete" ? summaryResult.text : "";
+      const result: CompactionResult = {
+        messagesBefore,
+        messagesAfter: newMessages.length,
+        tokensBefore,
+        tokensAfter,
+        summary,
+        compactedMessages: oldMessages,
+        newMessages,
+        trigger,
+        strategy,
+        structuredSummary,
+        summaryTier,
+      };
+
+      onCompact?.(result);
+      recordCompactionSuccess();
+
+      return result;
+    } catch (error) {
+      recordCompactionFailure();
+      throw error;
+    } finally {
+      activeCompactions--;
     }
-
-    // Build new message history
-    const summaryPrefix =
-      summaryTier !== undefined
-        ? `[Previous conversation summary - Tier ${summaryTier}]`
-        : "[Previous conversation summary]";
-
-    const summaryMessage: ModelMessage = {
-      role: "assistant" as const,
-      content: structuredSummary
-        ? `${summaryPrefix}\n\n${formatStructuredSummary(structuredSummary)}`
-        : `${summaryPrefix}\n\n${summary}`,
-    };
-
-    const newMessages: ModelMessage[] = [
-      ...systemMessages,
-      summaryMessage,
-      ...pinnedMessagesArray, // Include pinned messages
-      ...recentMessages,
-    ];
-
-    const tokensAfter = tokenCounter.countMessages(newMessages);
-
-    const result: CompactionResult = {
-      messagesBefore,
-      messagesAfter: newMessages.length,
-      tokensBefore,
-      tokensAfter,
-      summary,
-      compactedMessages: oldMessages,
-      newMessages,
-      trigger,
-      strategy,
-      structuredSummary,
-      summaryTier,
-    };
-
-    onCompact?.(result);
-
-    return result;
   };
 
   const process = async (messages: ModelMessage[], agent: Agent): Promise<ModelMessage[]> => {
@@ -1593,6 +1708,165 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+function getIndexedConversationMessages(messages: ModelMessage[]): IndexedMessage[] {
+  return messages
+    .map((message, originalIndex) => ({ message, originalIndex }))
+    .filter(({ message }) => message.role !== "system");
+}
+
+function getToolCallIds(message: ModelMessage): string[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+
+  return message.content.flatMap((part) =>
+    part.type === "tool-call" && typeof part.toolCallId === "string" ? [part.toolCallId] : [],
+  );
+}
+
+function getToolResultIds(message: ModelMessage): string[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+
+  return message.content.flatMap((part) =>
+    part.type === "tool-result" && typeof part.toolCallId === "string" ? [part.toolCallId] : [],
+  );
+}
+
+function findToolProtocolBlock(
+  messages: IndexedMessage[],
+  messagePosition: number,
+): { start: number; end: number } | undefined {
+  const current = messages[messagePosition];
+  if (!current) {
+    return undefined;
+  }
+
+  const currentToolCalls = getToolCallIds(current.message);
+  if (currentToolCalls.length > 0) {
+    return expandToolProtocolBlock(messages, messagePosition, new Set(currentToolCalls));
+  }
+
+  const currentToolResults = new Set(getToolResultIds(current.message));
+  if (currentToolResults.size === 0) {
+    return undefined;
+  }
+
+  for (let position = messagePosition - 1; position >= 0; position--) {
+    const candidate = messages[position];
+    if (!candidate) {
+      continue;
+    }
+
+    const candidateToolCalls = getToolCallIds(candidate.message);
+    if (candidateToolCalls.length === 0) {
+      continue;
+    }
+
+    if (candidateToolCalls.some((toolCallId) => currentToolResults.has(toolCallId))) {
+      return expandToolProtocolBlock(messages, position, new Set(candidateToolCalls));
+    }
+  }
+
+  return undefined;
+}
+
+function expandToolProtocolBlock(
+  messages: IndexedMessage[],
+  assistantPosition: number,
+  toolCallIds: Set<string>,
+): { start: number; end: number } {
+  let end = assistantPosition;
+
+  for (let position = assistantPosition + 1; position < messages.length; position++) {
+    const candidate = messages[position];
+    if (!candidate) {
+      break;
+    }
+
+    const toolResultIds = getToolResultIds(candidate.message);
+    if (toolResultIds.length === 0) {
+      break;
+    }
+
+    if (toolResultIds.some((toolCallId) => toolCallIds.has(toolCallId))) {
+      end = position;
+      continue;
+    }
+
+    break;
+  }
+
+  return { start: assistantPosition, end };
+}
+
+function collectRetainedConversationIndices(
+  messages: ModelMessage[],
+  options: {
+    pinnedIndices: Set<number>;
+    keepMessageCount: number;
+    keepToolResultCount: number;
+  },
+): Set<number> {
+  const { pinnedIndices, keepMessageCount, keepToolResultCount } = options;
+  const conversationMessages = getIndexedConversationMessages(messages);
+  const retainedIndices = new Set<number>();
+
+  for (const { originalIndex } of conversationMessages) {
+    if (pinnedIndices.has(originalIndex)) {
+      retainedIndices.add(originalIndex);
+    }
+  }
+
+  const unpinnedConversationMessages = conversationMessages.filter(
+    ({ originalIndex }) => !pinnedIndices.has(originalIndex),
+  );
+  if (keepMessageCount > 0) {
+    for (const { originalIndex } of unpinnedConversationMessages.slice(-keepMessageCount)) {
+      retainedIndices.add(originalIndex);
+    }
+  }
+
+  const toolResultMessages = conversationMessages.filter(
+    ({ message }) => getToolResultIds(message).length > 0,
+  );
+  if (keepToolResultCount > 0) {
+    for (const { originalIndex } of toolResultMessages.slice(-keepToolResultCount)) {
+      retainedIndices.add(originalIndex);
+    }
+  }
+
+  let expanded = true;
+  while (expanded) {
+    expanded = false;
+
+    for (let position = 0; position < conversationMessages.length; position++) {
+      const indexedMessage = conversationMessages[position];
+      if (!indexedMessage || !retainedIndices.has(indexedMessage.originalIndex)) {
+        continue;
+      }
+
+      const block = findToolProtocolBlock(conversationMessages, position);
+      if (!block) {
+        continue;
+      }
+
+      for (let blockPosition = block.start; blockPosition <= block.end; blockPosition++) {
+        const originalIndex = conversationMessages[blockPosition]?.originalIndex;
+        if (originalIndex === undefined || retainedIndices.has(originalIndex)) {
+          continue;
+        }
+
+        retainedIndices.add(originalIndex);
+        expanded = true;
+      }
+    }
+  }
+
+  return retainedIndices;
+}
 
 /**
  * Formats messages into a string suitable for summarization.

--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -335,12 +335,31 @@ export interface TokenBudget {
 export type CompactionPressureState = "normal" | "warning" | "blocking";
 
 /**
+ * Options for creating a token budget.
+ *
+ * @category Context
+ */
+export interface CreateTokenBudgetOptions {
+  /** Tokens reserved for model output. */
+  outputReserveTokens?: number;
+
+  /** Usage threshold for the warning state. */
+  warningThreshold?: number;
+
+  /** Usage threshold for the blocking state. */
+  blockingThreshold?: number;
+}
+
+/**
  * Creates a token budget from current usage.
  *
  * @param maxTokens - Maximum tokens allowed
  * @param currentTokens - Current token count
  * @param isActual - Whether this is based on actual model usage (default: false)
  * @param options - Effective budget options
+ * @param options.outputReserveTokens - Tokens reserved for model output
+ * @param options.warningThreshold - Usage threshold for the warning state
+ * @param options.blockingThreshold - Usage threshold for the blocking state
  * @returns A token budget object
  *
  * @category Context
@@ -349,11 +368,7 @@ export function createTokenBudget(
   maxTokens: number,
   currentTokens: number,
   isActual = false,
-  options: {
-    outputReserveTokens?: number;
-    warningThreshold?: number;
-    blockingThreshold?: number;
-  } = {},
+  options: CreateTokenBudgetOptions = {},
 ): TokenBudget {
   const outputReserveTokens = Math.max(0, options.outputReserveTokens ?? 0);
   const effectiveMaxTokens = Math.max(1, maxTokens - outputReserveTokens);
@@ -1317,8 +1332,6 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
   // Track pinned messages
   const pinnedMessages: PinnedMessageMetadata[] = [];
 
-  // Track summary tiers for tiered strategy
-  let currentSummaryTier = 0;
   let consecutiveCompactionFailures = 0;
   let compactionCircuitOpenUntil: number | undefined;
 
@@ -1468,6 +1481,10 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
       // If nothing to compact, return unchanged
       if (oldMessages.length === 0) {
+        if (trigger === "error_fallback" || shouldCompact(messages).trigger) {
+          throw new Error("Context compaction could not reduce the transcript");
+        }
+
         recordCompactionSuccess();
         return {
           messagesBefore,
@@ -1498,9 +1515,9 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
         if (existingSummaries.length >= (summarizationConfig.messagesPerTier ?? 5)) {
           // Create a higher-tier summary
-          currentSummaryTier = getNextSummaryTier(existingSummaries, currentSummaryTier);
+          const nextSummaryTier = getNextSummaryTier(existingSummaries);
           const summariesContent = formatMessagesForSummary(oldMessages);
-          const tierPrompt = TIERED_SUMMARY_PROMPT.replace("{tier}", String(currentSummaryTier));
+          const tierPrompt = TIERED_SUMMARY_PROMPT.replace("{tier}", String(nextSummaryTier));
 
           const summaryResult = await agent.generate({
             messages: [
@@ -1515,7 +1532,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
           });
 
           summary = getCompletedSummaryText(summaryResult);
-          summaryTier = currentSummaryTier;
+          summaryTier = nextSummaryTier;
         } else {
           // Create a first-tier summary
           const contentToSummarize = formatMessagesForSummary(oldMessages);
@@ -1622,8 +1639,13 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
         summaryTier,
       };
 
-      onCompact?.(result);
       recordCompactionSuccess();
+
+      try {
+        onCompact?.(result);
+      } catch {
+        // Callback failures should not poison the compaction circuit.
+      }
 
       return result;
     } catch (error) {
@@ -1778,7 +1800,7 @@ function getSummaryTierFromContent(content: string): number {
   return match[1] ? Number.parseInt(match[1], 10) : 0;
 }
 
-function getNextSummaryTier(existingSummaries: ModelMessage[], currentSummaryTier: number): number {
+function getNextSummaryTier(existingSummaries: ModelMessage[]): number {
   const highestTier = existingSummaries.reduce((maxTier, message) => {
     if (typeof message.content !== "string") {
       return maxTier;
@@ -1787,7 +1809,7 @@ function getNextSummaryTier(existingSummaries: ModelMessage[], currentSummaryTie
     return Math.max(maxTier, getSummaryTierFromContent(message.content));
   }, 0);
 
-  return Math.max(currentSummaryTier + 1, highestTier + 1);
+  return highestTier + 1;
 }
 
 function getCompletedSummaryText(result: { status: string; text?: string }): string {

--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -548,6 +548,36 @@ export interface PinnedMessageMetadata {
  */
 export interface SummarizationConfig {
   /**
+   * @deprecated Use `policy.enabled` instead.
+   */
+  enabled?: boolean;
+
+  /**
+   * @deprecated Use `policy.tokenThreshold` instead.
+   */
+  tokenThreshold?: number;
+
+  /**
+   * @deprecated Use `policy.hardCapThreshold` instead.
+   */
+  hardCapThreshold?: number;
+
+  /**
+   * @deprecated Use `policy.enableGrowthRatePrediction` instead.
+   */
+  enableGrowthRatePrediction?: boolean;
+
+  /**
+   * @deprecated Use `policy.enableErrorFallback` instead.
+   */
+  enableErrorFallback?: boolean;
+
+  /**
+   * @deprecated Use `policy.outputReserveTokens` instead.
+   */
+  outputReserveTokens?: number;
+
+  /**
    * Number of recent messages to always keep uncompacted.
    * These messages are preserved to maintain recent context.
    * @defaultValue 10
@@ -1268,8 +1298,10 @@ Format:
  */
 export function createContextManager(options: ContextManagerOptions): ContextManager {
   const tokenCounter = options.tokenCounter ?? createApproximateTokenCounter();
+  const legacyPolicy = getLegacyPolicyOverrides(options.summarization);
   const policy: CompactionPolicy = {
     ...DEFAULT_COMPACTION_POLICY,
+    ...legacyPolicy,
     ...options.policy,
   };
   const summarizationConfig: SummarizationConfig = {
@@ -1287,7 +1319,6 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
   // Track summary tiers for tiered strategy
   let currentSummaryTier = 0;
-  let activeCompactions = 0;
   let consecutiveCompactionFailures = 0;
   let compactionCircuitOpenUntil: number | undefined;
 
@@ -1407,12 +1438,6 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
       throw new Error("Context compaction circuit is open after repeated failures");
     }
 
-    if (activeCompactions > 0) {
-      throw new Error("Recursive context compaction is not allowed");
-    }
-
-    activeCompactions++;
-
     try {
       const tokensBefore = tokenCounter.countMessages(messages);
       const messagesBefore = messages.length;
@@ -1464,17 +1489,17 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 
       if (strategy === "tiered" && enableTieredSummaries) {
         // Tiered strategy: check if we have existing summaries to tier
-        const existingSummaries = messages.filter(
+        const existingSummaries = oldMessages.filter(
           (m) =>
             m.role === "assistant" &&
             typeof m.content === "string" &&
-            m.content.includes("[Previous conversation summary]"),
+            isSummaryMessageContent(m.content),
         );
 
         if (existingSummaries.length >= (summarizationConfig.messagesPerTier ?? 5)) {
           // Create a higher-tier summary
-          currentSummaryTier++;
-          const summariesContent = existingSummaries.map((m) => m.content).join("\n\n");
+          currentSummaryTier = getNextSummaryTier(existingSummaries, currentSummaryTier);
+          const summariesContent = formatMessagesForSummary(oldMessages);
           const tierPrompt = TIERED_SUMMARY_PROMPT.replace("{tier}", String(currentSummaryTier));
 
           const summaryResult = await agent.generate({
@@ -1489,7 +1514,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
             _skipCompaction: true, // Prevent recursive compaction during summary generation
           });
 
-          summary = summaryResult.status === "complete" ? summaryResult.text : "";
+          summary = getCompletedSummaryText(summaryResult);
           summaryTier = currentSummaryTier;
         } else {
           // Create a first-tier summary
@@ -1510,7 +1535,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
             _skipCompaction: true, // Prevent recursive compaction during summary generation
           });
 
-          summary = summaryResult.status === "complete" ? summaryResult.text : "";
+          summary = getCompletedSummaryText(summaryResult);
           summaryTier = 0;
 
           // Try to parse structured summary if enabled
@@ -1538,7 +1563,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
           _skipCompaction: true, // Prevent recursive compaction during summary generation
         });
 
-        summary = summaryResult.status === "complete" ? summaryResult.text : "";
+        summary = getCompletedSummaryText(summaryResult);
 
         // Try to parse structured summary
         try {
@@ -1563,7 +1588,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
           _skipCompaction: true, // Prevent recursive compaction during summary generation
         });
 
-        summary = summaryResult.status === "complete" ? summaryResult.text : "";
+        summary = getCompletedSummaryText(summaryResult);
       }
 
       // Build new message history
@@ -1604,8 +1629,6 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
     } catch (error) {
       recordCompactionFailure();
       throw error;
-    } finally {
-      activeCompactions--;
     }
   };
 
@@ -1708,6 +1731,72 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+const SUMMARY_PREFIX_PATTERN = /^\[Previous conversation summary(?: - Tier (\d+))?\]/;
+
+function getLegacyPolicyOverrides(
+  summarization: Partial<SummarizationConfig> | undefined,
+): Partial<CompactionPolicy> {
+  if (!summarization) {
+    return {};
+  }
+
+  const legacyPolicy: Partial<CompactionPolicy> = {};
+
+  if (summarization.enabled !== undefined) {
+    legacyPolicy.enabled = summarization.enabled;
+  }
+  if (summarization.tokenThreshold !== undefined) {
+    legacyPolicy.tokenThreshold = summarization.tokenThreshold;
+  }
+  if (summarization.hardCapThreshold !== undefined) {
+    legacyPolicy.hardCapThreshold = summarization.hardCapThreshold;
+  }
+  if (summarization.enableGrowthRatePrediction !== undefined) {
+    legacyPolicy.enableGrowthRatePrediction = summarization.enableGrowthRatePrediction;
+  }
+  if (summarization.enableErrorFallback !== undefined) {
+    legacyPolicy.enableErrorFallback = summarization.enableErrorFallback;
+  }
+  if (summarization.outputReserveTokens !== undefined) {
+    legacyPolicy.outputReserveTokens = summarization.outputReserveTokens;
+  }
+
+  return legacyPolicy;
+}
+
+function isSummaryMessageContent(content: string): boolean {
+  return SUMMARY_PREFIX_PATTERN.test(content);
+}
+
+function getSummaryTierFromContent(content: string): number {
+  const match = content.match(SUMMARY_PREFIX_PATTERN);
+  if (!match) {
+    return 0;
+  }
+
+  return match[1] ? Number.parseInt(match[1], 10) : 0;
+}
+
+function getNextSummaryTier(existingSummaries: ModelMessage[], currentSummaryTier: number): number {
+  const highestTier = existingSummaries.reduce((maxTier, message) => {
+    if (typeof message.content !== "string") {
+      return maxTier;
+    }
+
+    return Math.max(maxTier, getSummaryTierFromContent(message.content));
+  }, 0);
+
+  return Math.max(currentSummaryTier + 1, highestTier + 1);
+}
+
+function getCompletedSummaryText(result: { status: string; text?: string }): string {
+  if (result.status !== "complete") {
+    throw new Error("Summary generation did not complete");
+  }
+
+  return result.text ?? "";
+}
 
 function getIndexedConversationMessages(messages: ModelMessage[]): IndexedMessage[] {
   return messages

--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -374,8 +374,7 @@ export function createTokenBudget(
   const effectiveMaxTokens = Math.max(1, maxTokens - outputReserveTokens);
   const usage = currentTokens / effectiveMaxTokens;
   const warningThreshold = options.warningThreshold ?? DEFAULT_COMPACTION_POLICY.tokenThreshold;
-  const blockingThreshold =
-    options.blockingThreshold ?? DEFAULT_COMPACTION_POLICY.hardCapThreshold;
+  const blockingThreshold = options.blockingThreshold ?? DEFAULT_COMPACTION_POLICY.hardCapThreshold;
 
   let state: CompactionPressureState = "normal";
   if (usage >= blockingThreshold) {
@@ -1366,10 +1365,7 @@ export function createContextManager(options: ContextManagerOptions): ContextMan
   };
 
   const isCompactionCircuitOpen = (): boolean => {
-    if (
-      compactionCircuitOpenUntil !== undefined &&
-      Date.now() >= compactionCircuitOpenUntil
-    ) {
+    if (compactionCircuitOpenUntil !== undefined && Date.now() >= compactionCircuitOpenUntil) {
       compactionCircuitOpenUntil = undefined;
       consecutiveCompactionFailures = 0;
     }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -154,6 +154,7 @@ export type {
   CompactionTrigger,
   ContextManager,
   ContextManagerOptions,
+  CreateTokenBudgetOptions,
   CustomTokenCounterOptions,
   PinnedMessageMetadata,
   StructuredSummary,

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -143,6 +143,7 @@ export {
 } from "./checkpointer/index.js";
 // Context Manager types
 export type {
+  CompactionPressureState,
   CompactionPolicy,
   CompactionResult,
   CompactionScheduler,

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -595,8 +595,11 @@ export interface AgentOptions {
    *   model,
    *   contextManager: createContextManager({
    *     maxTokens: 100000,
-   *     summarization: {
+   *     policy: {
    *       tokenThreshold: 0.75, // Compact at 75% capacity
+   *       outputReserveTokens: 4000, // Reserve room for the next response
+   *     },
+   *     summarization: {
    *       keepMessageCount: 10, // Keep last 10 messages
    *     },
    *     onCompact: (result) => {

--- a/packages/agent-sdk/tests/compaction-error-fallback.test.ts
+++ b/packages/agent-sdk/tests/compaction-error-fallback.test.ts
@@ -364,7 +364,7 @@ describe("Error-Triggered Compaction Fallback", () => {
       });
 
       const messages: ModelMessage[] = Array.from({ length: 10 }, (_, index) => ({
-        role: "user",
+        role: "user" as const,
         content: `Message ${index} with enough content to trigger fallback`,
       }));
 

--- a/packages/agent-sdk/tests/compaction-error-fallback.test.ts
+++ b/packages/agent-sdk/tests/compaction-error-fallback.test.ts
@@ -333,5 +333,49 @@ describe("Error-Triggered Compaction Fallback", () => {
       // Should attempt: initial + 3 retries = 4 total
       expect(generateCallCount).toBeLessThanOrEqual(4);
     });
+
+    it("should not recursively retry compaction while generating a summary", async () => {
+      let generateCallCount = 0;
+
+      const mockModel = createMockModelWithBehavior(async () => {
+        generateCallCount++;
+        throw new Error("Context length exceeded");
+      });
+
+      const contextManager = createContextManager({
+        maxTokens: 1000,
+        policy: {
+          enabled: true,
+          tokenThreshold: 0.8,
+          hardCapThreshold: 0.95,
+          enableGrowthRatePrediction: false,
+          enableErrorFallback: true,
+        },
+        summarization: {
+          keepMessageCount: 2,
+          keepToolResultCount: 0,
+        },
+      });
+
+      const agent = createAgent({
+        name: "test-agent",
+        model: mockModel,
+        contextManager,
+      });
+
+      const messages: ModelMessage[] = Array.from({ length: 10 }, (_, index) => ({
+        role: "user",
+        content: `Message ${index} with enough content to trigger fallback`,
+      }));
+
+      await expect(
+        agent.generate({
+          messages,
+          maxRetries: 0,
+        }),
+      ).rejects.toThrow("Context length exceeded");
+
+      expect(generateCallCount).toBe(2);
+    });
   });
 });

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -534,8 +534,12 @@ describe("createContextManager", () => {
       ];
 
       const result = await manager.compact(messages, mockAgent);
-      const retainedAssistant = result.newMessages.find((message) => message === assistantToolMessage);
-      const retainedToolResult = result.newMessages.find((message) => message === toolResultMessage);
+      const retainedAssistant = result.newMessages.find(
+        (message) => message === assistantToolMessage,
+      );
+      const retainedToolResult = result.newMessages.find(
+        (message) => message === toolResultMessage,
+      );
 
       expect(retainedAssistant).toBeDefined();
       expect(retainedToolResult).toBeDefined();

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -287,11 +287,11 @@ describe("createContextManager", () => {
     it("should merge custom config with defaults", () => {
       const manager = createContextManager({
         maxTokens: 1000,
-        summarization: {
+        policy: {
           tokenThreshold: 0.9,
         },
       });
-      expect(manager.summarizationConfig.tokenThreshold).toBe(0.9);
+      expect(manager.policy.tokenThreshold).toBe(0.9);
       expect(manager.summarizationConfig.keepMessageCount).toBe(10); // Default
     });
   });
@@ -320,6 +320,27 @@ describe("createContextManager", () => {
 
       expect(onBudgetUpdate).toHaveBeenCalled();
       expect(onBudgetUpdate.mock.calls[0][0]).toHaveProperty("maxTokens");
+    });
+
+    it("should reserve output headroom when calculating the effective budget", () => {
+      const manager = createContextManager({
+        maxTokens: 100,
+        tokenCounter: createCustomTokenCounter({
+          countFn: () => 30,
+        }),
+        policy: {
+          outputReserveTokens: 20,
+        },
+      });
+
+      const budget = manager.getBudget([{ role: "user", content: "hello world" }]);
+
+      expect(budget.maxTokens).toBe(100);
+      expect(budget.effectiveMaxTokens).toBe(80);
+      expect(budget.outputReserveTokens).toBe(20);
+      expect(budget.currentTokens).toBe(34);
+      expect(budget.remaining).toBe(46);
+      expect(budget.state).toBe("normal");
     });
   });
 
@@ -353,6 +374,36 @@ describe("createContextManager", () => {
       });
       const messages = createTestMessages(5);
       expect(manager.shouldCompact(messages).trigger).toBe(true);
+    });
+
+    it("should trigger compaction against the effective budget after output reservation", () => {
+      const manager = createContextManager({
+        maxTokens: 100,
+        tokenCounter: createCustomTokenCounter({
+          countFn: () => 25,
+        }),
+        policy: {
+          outputReserveTokens: 30,
+          tokenThreshold: 0.8,
+        },
+      });
+
+      const messages: ModelMessage[] = [{ role: "user", content: "headroom test" }];
+      const budget = manager.getBudget(messages);
+      const result = manager.shouldCompact(messages);
+
+      expect(budget.effectiveMaxTokens).toBe(70);
+      expect(budget.usage).toBeCloseTo(29 / 70);
+      expect(result).toEqual({ trigger: false });
+
+      const largerMessages: ModelMessage[] = [
+        { role: "user", content: "headroom test" },
+        { role: "assistant", content: "second message" },
+      ];
+      const largerResult = manager.shouldCompact(largerMessages);
+
+      expect(largerResult.trigger).toBe(true);
+      expect(largerResult.reason).toBe("token_threshold");
     });
   });
 
@@ -424,6 +475,94 @@ describe("createContextManager", () => {
       await manager.compact(messages, mockAgent);
 
       expect(onCompact).toHaveBeenCalled();
+    });
+
+    it("should preserve tool-call and tool-result blocks when retaining recent history", async () => {
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: {
+          keepMessageCount: 2,
+          keepToolResultCount: 0,
+        },
+      });
+
+      const assistantToolMessage: ModelMessage = {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking that now." },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            input: { query: "agent sdk issue 101" },
+          },
+        ],
+      };
+      const toolResultMessage: ModelMessage = {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "search",
+            output: { result: "Found issue details" },
+          },
+        ],
+      };
+      const messages: ModelMessage[] = [
+        { role: "user", content: "Earlier context" },
+        assistantToolMessage,
+        toolResultMessage,
+        { role: "user", content: "Continue from there" },
+      ];
+
+      const result = await manager.compact(messages, mockAgent);
+      const retainedAssistant = result.newMessages.find((message) => message === assistantToolMessage);
+      const retainedToolResult = result.newMessages.find((message) => message === toolResultMessage);
+
+      expect(retainedAssistant).toBeDefined();
+      expect(retainedToolResult).toBeDefined();
+      expect(Array.isArray(retainedAssistant?.content)).toBe(true);
+      expect(
+        Array.isArray(retainedAssistant?.content) ? retainedAssistant.content : [],
+      ).toHaveLength(2);
+    });
+
+    it("should stop retrying compaction after repeated failures until cooldown expires", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const failingAgent = createMockAgent({
+          generate: vi.fn().mockRejectedValue(new Error("summary failed")),
+        });
+        const manager = createContextManager({
+          maxTokens: 100,
+          policy: {
+            tokenThreshold: 0.1,
+            maxConsecutiveFailures: 2,
+            failureCooldownMs: 1000,
+          },
+          summarization: {
+            keepMessageCount: 1,
+          },
+        });
+        const messages = createTestMessages(8);
+
+        await expect(manager.compact(messages, failingAgent)).rejects.toThrow("summary failed");
+        await expect(manager.compact(messages, failingAgent)).rejects.toThrow("summary failed");
+        await expect(manager.compact(messages, failingAgent)).rejects.toThrow(
+          "Context compaction circuit is open after repeated failures",
+        );
+        expect(failingAgent.generate).toHaveBeenCalledTimes(2);
+        expect(manager.shouldCompact(messages)).toEqual({ trigger: false });
+
+        vi.advanceTimersByTime(1000);
+
+        await expect(manager.compact(messages, failingAgent)).rejects.toThrow("summary failed");
+        expect(failingAgent.generate).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -707,7 +707,7 @@ describe("createContextManager", () => {
       expect(resultB.summaryTier).toBe(1);
     });
 
-    it("should fail when pressure-triggered compaction cannot remove any messages", async () => {
+    it("should fail when error-fallback compaction cannot remove any messages", async () => {
       const manager = createContextManager({
         maxTokens: 100,
         tokenCounter: createCustomTokenCounter({
@@ -722,7 +722,7 @@ describe("createContextManager", () => {
       });
       const messages: ModelMessage[] = [{ role: "user", content: "only message" }];
 
-      await expect(manager.compact(messages, mockAgent, "token_threshold")).rejects.toThrow(
+      await expect(manager.compact(messages, mockAgent, "error_fallback")).rejects.toThrow(
         "Context compaction could not reduce the transcript",
       );
     });

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -294,6 +294,23 @@ describe("createContextManager", () => {
       expect(manager.policy.tokenThreshold).toBe(0.9);
       expect(manager.summarizationConfig.keepMessageCount).toBe(10); // Default
     });
+
+    it("should honor deprecated policy keys passed via summarization config", () => {
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: {
+          tokenThreshold: 0.7,
+          hardCapThreshold: 0.9,
+          enableErrorFallback: false,
+          keepMessageCount: 4,
+        },
+      });
+
+      expect(manager.policy.tokenThreshold).toBe(0.7);
+      expect(manager.policy.hardCapThreshold).toBe(0.9);
+      expect(manager.policy.enableErrorFallback).toBe(false);
+      expect(manager.summarizationConfig.keepMessageCount).toBe(4);
+    });
   });
 
   describe("getBudget", () => {
@@ -563,6 +580,89 @@ describe("createContextManager", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("should throw when summary generation does not complete", async () => {
+      const interruptedAgent = createMockAgent({
+        generate: vi.fn().mockResolvedValue({
+          status: "interrupted",
+          interrupt: {
+            id: "interrupt-1",
+            type: "approval",
+            toolCallId: "call-1",
+            toolName: "search",
+            request: { toolName: "search", args: {} },
+          },
+          partial: {
+            text: "",
+            steps: [],
+            usage: undefined,
+          },
+        }),
+      });
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: { keepMessageCount: 1 },
+      });
+
+      await expect(manager.compact(createTestMessages(8), interruptedAgent)).rejects.toThrow(
+        "Summary generation did not complete",
+      );
+    });
+
+    it("should include raw history when promoting tiered summaries", async () => {
+      const tieredAgent = createMockAgent({
+        generate: vi.fn().mockResolvedValue({
+          status: "complete",
+          text: "## Tiered Summary (Level 1)\nPromoted summary",
+          usage: { inputTokens: 100, outputTokens: 50 },
+          finishReason: "stop",
+          steps: [],
+        }),
+      });
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: {
+          keepMessageCount: 1,
+          strategy: "tiered",
+          enableTieredSummaries: true,
+          messagesPerTier: 2,
+        },
+      });
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: "[Previous conversation summary - Tier 0]\n\nSummary 1",
+        },
+        {
+          role: "assistant",
+          content: "[Previous conversation summary - Tier 0]\n\nSummary 2",
+        },
+        { role: "user", content: "Raw unsummarized detail" },
+        { role: "assistant", content: "Newest message" },
+      ];
+
+      const result = await manager.compact(messages, tieredAgent);
+
+      expect(result.summaryTier).toBe(1);
+      expect(tieredAgent.generate).toHaveBeenCalledTimes(1);
+      expect(tieredAgent.generate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: "system" }),
+            expect.objectContaining({
+              role: "user",
+              content: expect.stringContaining("Raw unsummarized detail"),
+            }),
+          ]),
+        }),
+      );
+      expect(result.newMessages[0]).toEqual(
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.stringContaining("Tier 1"),
+        }),
+      );
     });
   });
 

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -664,6 +664,81 @@ describe("createContextManager", () => {
         }),
       );
     });
+
+    it("should keep tier promotion local to the current transcript", async () => {
+      const tieredAgent = createMockAgent({
+        generate: vi.fn().mockResolvedValue({
+          status: "complete",
+          text: "## Tiered Summary\nPromoted summary",
+          usage: { inputTokens: 100, outputTokens: 50 },
+          finishReason: "stop",
+          steps: [],
+        }),
+      });
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: {
+          keepMessageCount: 1,
+          strategy: "tiered",
+          enableTieredSummaries: true,
+          messagesPerTier: 2,
+        },
+      });
+
+      const transcriptA: ModelMessage[] = [
+        { role: "assistant", content: "[Previous conversation summary - Tier 0]\n\nSummary A1" },
+        { role: "assistant", content: "[Previous conversation summary - Tier 0]\n\nSummary A2" },
+        { role: "assistant", content: "Newest A" },
+      ];
+      const transcriptB: ModelMessage[] = [
+        { role: "assistant", content: "[Previous conversation summary - Tier 0]\n\nSummary B1" },
+        { role: "assistant", content: "[Previous conversation summary - Tier 0]\n\nSummary B2" },
+        { role: "assistant", content: "Newest B" },
+      ];
+
+      const resultA = await manager.compact(transcriptA, tieredAgent);
+      const resultB = await manager.compact(transcriptB, tieredAgent);
+
+      expect(resultA.summaryTier).toBe(1);
+      expect(resultB.summaryTier).toBe(1);
+    });
+
+    it("should fail when pressure-triggered compaction cannot remove any messages", async () => {
+      const manager = createContextManager({
+        maxTokens: 100,
+        tokenCounter: createCustomTokenCounter({
+          countFn: () => 80,
+        }),
+        policy: {
+          tokenThreshold: 0.5,
+        },
+        summarization: {
+          keepMessageCount: 5,
+        },
+      });
+      const messages: ModelMessage[] = [{ role: "user", content: "only message" }];
+
+      await expect(manager.compact(messages, mockAgent, "token_threshold")).rejects.toThrow(
+        "Context compaction could not reduce the transcript",
+      );
+    });
+
+    it("should ignore onCompact callback errors for breaker accounting", async () => {
+      const manager = createContextManager({
+        maxTokens: 1000,
+        summarization: { keepMessageCount: 1 },
+        onCompact: () => {
+          throw new Error("observer failed");
+        },
+      });
+      const messages = createTestMessages(8);
+
+      const result = await manager.compact(messages, mockAgent);
+      const secondResult = await manager.compact(messages, mockAgent);
+
+      expect(result.summary).toContain("Summary");
+      expect(secondResult.summary).toContain("Summary");
+    });
   });
 
   describe("process", () => {


### PR DESCRIPTION
## Summary
- add protocol-aware context compaction with output headroom, pressure states, transcript retention invariants, and failure cooldowns
- guard compaction fallback paths against recursive summary-generation retries
- document the new compaction behavior and add focused regression coverage

## Testing
- `bun test packages/agent-sdk/tests/context-manager.test.ts`

## Notes
- broader agent-side tests and workspace type-check were not runnable in this worktree because dependencies are missing (`ai` could not be resolved and `tsc` was unavailable)

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context compaction is now protocol-aware: preserves tool-call/tool-result blocks and multipart assistant messages.
  * Token budgeting can reserve output headroom (output reserve) and reports effective prompt budget and pressure state.
  * Repeated compaction failures now open a bounded cooldown circuit to stop endless retries.

* **Bug Fixes**
  * Prevents recursive compaction during error-fallback summarisation, avoiding runaway retries.

* **Documentation**
  * README, API reference and guides updated to document new compaction policy, budget fields and behaviour.

* **Tests**
  * Added tests for compaction behaviour, error-fallback and circuit-breaker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->