### PR TITLE
LLE-8692 feat(agent-threads): carry skillId and componentId on tool parts

### DIFF
--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ToolCallPart` and `ToolResultPart` now carry optional `skillId` and `componentId` fields so consumers can attribute tool invocations back to the originating skill component. The accumulator threads both fields from `tool-call` / `tool-result` stream payloads into canonical parts, and falls back to values captured on the pending `tool-call` when a `tool-result` omits them.
+
 ## [0.1.0-alpha.3] - 2026-02-28
 
 ### Added

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -29,7 +29,10 @@ export interface AccumulatorState {
   /** Text buffer for coalescing consecutive text-deltas */
   textBuffer: string;
   /** Pending tool calls awaiting results */
-  pendingToolCalls: Map<string, { toolName: string; input: unknown }>;
+  pendingToolCalls: Map<
+    string,
+    { toolName: string; input: unknown; skillId?: string; componentId?: string }
+  >;
   /** ID of the last committed message */
   lastMessageId: string | null;
 }
@@ -139,16 +142,26 @@ function createReducer(
       case "tool-call": {
         ensureCurrentMessage(state, idGen);
         flushTextBuffer(state);
-        const p = payload as { toolCallId: string; toolName: string; input: unknown };
+        const p = payload as {
+          toolCallId: string;
+          toolName: string;
+          input: unknown;
+          skillId?: string;
+          componentId?: string;
+        };
         state.currentMessage!.parts.push({
           type: "tool-call",
           toolCallId: p.toolCallId,
           toolName: p.toolName,
           input: p.input,
+          ...(p.skillId !== undefined && { skillId: p.skillId }),
+          ...(p.componentId !== undefined && { componentId: p.componentId }),
         });
         state.pendingToolCalls.set(p.toolCallId, {
           toolName: p.toolName,
           input: p.input,
+          ...(p.skillId !== undefined && { skillId: p.skillId }),
+          ...(p.componentId !== undefined && { componentId: p.componentId }),
         });
         break;
       }
@@ -162,9 +175,13 @@ function createReducer(
           toolName: string;
           output: unknown;
           isError?: boolean;
+          skillId?: string;
+          componentId?: string;
         };
         const pending = state.pendingToolCalls.get(p.toolCallId);
         const toolName = p.toolName ?? pending?.toolName ?? "unknown";
+        const skillId = p.skillId ?? pending?.skillId;
+        const componentId = p.componentId ?? pending?.componentId;
         state.pendingToolCalls.delete(p.toolCallId);
 
         const toolMsg: CanonicalMessage = {
@@ -178,6 +195,8 @@ function createReducer(
               toolName,
               output: p.output,
               isError: p.isError ?? false,
+              ...(skillId !== undefined && { skillId }),
+              ...(componentId !== undefined && { componentId }),
             },
           ],
           createdAt: new Date().toISOString(),

--- a/packages/agent-threads/src/ledger/types.ts
+++ b/packages/agent-threads/src/ledger/types.ts
@@ -38,6 +38,10 @@ export interface ToolCallPart {
   readonly toolCallId: string;
   readonly toolName: string;
   readonly input: unknown;
+  /** Stable id of the skill that owns this tool, when the tool came from a skill component */
+  readonly skillId?: string;
+  /** Stable id of the originating skill component, when the tool came from a skill component */
+  readonly componentId?: string;
 }
 
 /**
@@ -51,6 +55,10 @@ export interface ToolResultPart {
   readonly toolName: string;
   readonly output: unknown;
   readonly isError: boolean;
+  /** Stable id of the skill that owns this tool, when the tool came from a skill component */
+  readonly skillId?: string;
+  /** Stable id of the originating skill component, when the tool came from a skill component */
+  readonly componentId?: string;
 }
 
 /**

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -256,6 +256,107 @@ describe("Accumulator", () => {
       expect(messages[0]!.metadata).toHaveProperty("schemaVersion", 1);
     });
 
+    it("carries skillId and componentId from tool-call payloads onto canonical parts", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "gmail_send",
+            input: { subject: "hi" },
+            skillId: "skl-gmail",
+            componentId: "skl-comp-gmail-cred",
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "gmail_send",
+            output: "ok",
+            isError: false,
+            skillId: "skl-gmail",
+            componentId: "skl-comp-gmail-cred",
+          },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const toolCallPart = messages[0]!.parts[0] as Extract<CanonicalPart, { type: "tool-call" }>;
+      expect(toolCallPart.skillId).toBe("skl-gmail");
+      expect(toolCallPart.componentId).toBe("skl-comp-gmail-cred");
+
+      const toolResultPart = messages[1]!.parts[0] as Extract<
+        CanonicalPart,
+        { type: "tool-result" }
+      >;
+      expect(toolResultPart.skillId).toBe("skl-gmail");
+      expect(toolResultPart.componentId).toBe("skl-comp-gmail-cred");
+    });
+
+    it("falls back to pending tool-call metadata when tool-result omits skillId/componentId", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-2",
+            toolName: "drive_read",
+            input: {},
+            skillId: "skl-drive",
+            componentId: "skl-comp-drive-wf",
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-2",
+            toolName: "drive_read",
+            output: "ok",
+            isError: false,
+          },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const toolResultPart = messages[1]!.parts[0] as Extract<
+        CanonicalPart,
+        { type: "tool-result" }
+      >;
+      expect(toolResultPart.skillId).toBe("skl-drive");
+      expect(toolResultPart.componentId).toBe("skl-comp-drive-wf");
+    });
+
+    it("omits skillId/componentId entirely when payloads do not provide them", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        { kind: "tool-call", payload: { toolCallId: "tc-3", toolName: "plain", input: {} } },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        {
+          kind: "tool-result",
+          payload: { toolCallId: "tc-3", toolName: "plain", output: "ok", isError: false },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const toolCallPart = messages[0]!.parts[0] as Extract<CanonicalPart, { type: "tool-call" }>;
+      const toolResultPart = messages[1]!.parts[0] as Extract<
+        CanonicalPart,
+        { type: "tool-result" }
+      >;
+
+      expect(toolCallPart).not.toHaveProperty("skillId");
+      expect(toolCallPart).not.toHaveProperty("componentId");
+      expect(toolResultPart).not.toHaveProperty("skillId");
+      expect(toolResultPart).not.toHaveProperty("componentId");
+    });
+
     it("handles user-message events as canonical user messages", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([


### PR DESCRIPTION
## Summary

- Adds optional `skillId` and `componentId` fields to `ToolCallPart` and `ToolResultPart`, so consumers of the canonical transcript can attribute tool invocations back to the originating skill component.
- Accumulator threads both fields from `tool-call` / `tool-result` stream payloads into canonical parts, and falls back to the values captured on the pending `tool-call` when the matching `tool-result` omits them.

## Why

LLE-8692 is hooking up the Agent sidebar's "Context" section to live backend data. The section needs to render the skill components the agent has actually used during a thread, which means each tool invocation needs a stable identifier the consumer can resolve back to a `SkillComponent` row. The existing `toolName` string isn't stable — multiple skills can expose tools with the same name, and there's no mapping back from tool name to component id.

These fields are purely additive and optional; they have no effect on anything that isn't looking for them.

## Test plan

- [x] New unit tests in `tests/ledger/accumulator.test.ts`:
  - `skillId`/`componentId` from both `tool-call` and `tool-result` payloads land on the canonical parts.
  - When a `tool-result` payload omits the ids, the accumulator falls back to the values captured on the pending `tool-call`.
  - When neither event carries the ids, the resulting parts don't include the fields at all (no `undefined` leakage).
- [x] Full `tests/ledger/accumulator.test.ts` suite passes (27/27).
- [x] `bun run --filter '@lleverage-ai/agent-threads' type-check` passes.
- [x] `bun run check` (biome) passes on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls and results now include optional `skillId` and `componentId` metadata fields to track skill and component provenance.
  * Tool results automatically inherit skill and component identifiers from corresponding tool calls when not explicitly provided.

* **Tests**
  * Added comprehensive test coverage for skill and component identifier propagation across tool call and result events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->