### PR TITLE
chore(release): prepare alpha versions for agent-sdk and agent-threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1] - 2026-04-14
+
 ### Added
 
 - `@lleverage-ai/agent-threads` — new unified package merging `@lleverage-ai/agent-stream` (event transport/replay) and `@lleverage-ai/agent-ledger` (durable transcripts/run lifecycle) into a single package with subpath exports (`./stream`, `./ledger`, `./server`, `./client`, `./stores/*`)
@@ -270,7 +272,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error types and graceful degradation utilities
 - Testing utilities via `@lleverage-ai/agent-sdk/testing`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.13...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.1...HEAD
+[0.1.0-alpha.1]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.0.14...agent-sdk@0.1.0-alpha.1
+[0.0.14]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.13...agent-sdk@0.0.14
 [0.0.13]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.10...v0.0.11

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/agent-sdk": {
       "name": "@lleverage-ai/agent-sdk",
-      "version": "0.0.13",
+      "version": "0.1.0-alpha.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ajv": "^8.17.1",
@@ -34,7 +34,7 @@
     },
     "packages/agent-threads": {
       "name": "@lleverage-ai/agent-threads",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "devDependencies": {
         "vitest": "^4.0.18",
         "zod": "^4.3.6",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.0.14",
+  "version": "0.1.0-alpha.1",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4] - 2026-04-14
+
 ### Added
 
 - `ToolCallPart` and `ToolResultPart` now carry optional `toolLabel`, `skillName`, and `skillIcon` metadata from stream events, so canonical transcripts preserve the same display labels shown during streaming
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ledger layer: canonical message schema, `RunManager`, accumulator, reconciliation, `FullContextBuilder`, ledger stores (`InMemoryLedgerStore`, `SQLiteLedgerStore`)
 - Subpath exports for granular imports: `./stream`, `./ledger`, `./server`, `./client`, `./stores/*`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.3...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.4...HEAD
+[0.1.0-alpha.4]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.3...agent-threads@0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.2...agent-threads@0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.1...agent-threads@0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/lleverage-ai/agent-sdk/releases/tag/agent-threads@0.1.0-alpha.1

--- a/packages/agent-threads/package.json
+++ b/packages/agent-threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-threads",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Event transport, replay, and durable transcripts for AI agent conversations",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `@lleverage-ai/agent-sdk` to `0.1.0-alpha.1`
- bump `@lleverage-ai/agent-threads` to `0.1.0-alpha.4`
- move current unreleased entries into dated alpha changelog sections and update compare links
- sync workspace version metadata in `bun.lock`

## Validation
- `bun run check` (passes with a non-failing Biome schema/CLI version info message: config `2.4.4`, CLI `2.3.14`)
- `bun run type-check`
- `bun run test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released agent-sdk v0.1.0-alpha.1
  * Released agent-threads v0.1.0-alpha.4
  * Updated package version numbers and release documentation
  * Enhanced transcript metadata handling in agent-threads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->