### PR TITLE
Fix proxied inline tool interrupt flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
+
 ## [0.1.0-alpha.1] - 2026-04-14
 
 ### Added

--- a/packages/agent-sdk/src/mcp/execution-options.ts
+++ b/packages/agent-sdk/src/mcp/execution-options.ts
@@ -1,0 +1,25 @@
+import type { ToolExecutionOptions } from "ai";
+import type { ExtendedToolExecutionOptions, StreamingContext } from "../types.js";
+
+export type ProxyToolCallOptions = Partial<ExtendedToolExecutionOptions> & {
+  streamingContext?: StreamingContext | null;
+};
+
+export type NormalizedInlineToolExecutionOptions = Omit<
+  ProxyToolCallOptions,
+  "streamingContext" | "toolCallId" | "messages" | "abortSignal"
+> &
+  Pick<ToolExecutionOptions, "toolCallId" | "messages" | "abortSignal">;
+
+export function createInlineToolExecutionOptions(
+  options: ProxyToolCallOptions = {},
+): NormalizedInlineToolExecutionOptions {
+  const { streamingContext: _streamingContext, ...toolExecutionOptions } = options;
+
+  return {
+    ...toolExecutionOptions,
+    toolCallId: toolExecutionOptions.toolCallId ?? `virtual-${Date.now()}`,
+    messages: toolExecutionOptions.messages ?? [],
+    abortSignal: toolExecutionOptions.abortSignal ?? new AbortController().signal,
+  };
+}

--- a/packages/agent-sdk/src/mcp/manager.ts
+++ b/packages/agent-sdk/src/mcp/manager.ts
@@ -14,7 +14,6 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { type Tool, type ToolSet, tool } from "ai";
 import { formatMcpToolName, isMcpToolName } from "../tool-names.js";
 import type {
-  ExtendedToolExecutionOptions,
   HttpMCPServerConfig,
   MCPServerConfig,
   SseMCPServerConfig,
@@ -23,24 +22,13 @@ import type {
   StreamingToolsFactory,
 } from "../types.js";
 import { expandEnvVars } from "./env.js";
+import {
+  createInlineToolExecutionOptions,
+  type ProxyToolCallOptions,
+} from "./execution-options.js";
 import type { MCPToolLoadResult, MCPToolMetadata, MCPToolSource } from "./types.js";
 import { isSchemaEmpty, jsonSchemaToZod, MCPInputValidator } from "./validation.js";
 import { VirtualMCPServer } from "./virtual-server.js";
-
-type ProxyToolCallOptions = Partial<ExtendedToolExecutionOptions> & {
-  streamingContext?: StreamingContext | null;
-};
-
-function createInlineToolExecutionOptions(options: ProxyToolCallOptions = {}) {
-  const { streamingContext: _streamingContext, ...toolExecutionOptions } = options;
-
-  return {
-    ...toolExecutionOptions,
-    toolCallId: toolExecutionOptions.toolCallId ?? `virtual-${Date.now()}`,
-    messages: toolExecutionOptions.messages ?? [],
-    abortSignal: toolExecutionOptions.abortSignal ?? new AbortController().signal,
-  };
-}
 
 /**
  * Connected external MCP client with metadata.

--- a/packages/agent-sdk/src/mcp/manager.ts
+++ b/packages/agent-sdk/src/mcp/manager.ts
@@ -14,6 +14,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { type Tool, type ToolSet, tool } from "ai";
 import { formatMcpToolName, isMcpToolName } from "../tool-names.js";
 import type {
+  ExtendedToolExecutionOptions,
   HttpMCPServerConfig,
   MCPServerConfig,
   SseMCPServerConfig,
@@ -25,6 +26,21 @@ import { expandEnvVars } from "./env.js";
 import type { MCPToolLoadResult, MCPToolMetadata, MCPToolSource } from "./types.js";
 import { isSchemaEmpty, jsonSchemaToZod, MCPInputValidator } from "./validation.js";
 import { VirtualMCPServer } from "./virtual-server.js";
+
+type ProxyToolCallOptions = Partial<ExtendedToolExecutionOptions> & {
+  streamingContext?: StreamingContext | null;
+};
+
+function createInlineToolExecutionOptions(options: ProxyToolCallOptions = {}) {
+  const { streamingContext: _streamingContext, ...toolExecutionOptions } = options;
+
+  return {
+    ...toolExecutionOptions,
+    toolCallId: toolExecutionOptions.toolCallId ?? `virtual-${Date.now()}`,
+    messages: toolExecutionOptions.messages ?? [],
+    abortSignal: toolExecutionOptions.abortSignal ?? new AbortController().signal,
+  };
+}
 
 /**
  * Connected external MCP client with metadata.
@@ -949,10 +965,7 @@ export class MCPManager {
   async callTool(
     qualifiedName: string,
     args: unknown,
-    options: {
-      abortSignal?: AbortSignal;
-      streamingContext?: StreamingContext | null;
-    } = {},
+    options: ProxyToolCallOptions = {},
   ): Promise<unknown> {
     const mcpTool = isMcpToolName(qualifiedName);
     const parts = qualifiedName.split("__");
@@ -977,16 +990,15 @@ export class MCPManager {
             const liveTools = factory(options.streamingContext ?? { writer: null });
             const liveTool = liveTools[toolName];
             if (liveTool?.execute) {
-              return liveTool.execute(args as Parameters<typeof liveTool.execute>[0], {
-                toolCallId: `virtual-${Date.now()}`,
-                messages: [],
-                abortSignal: options.abortSignal ?? new AbortController().signal,
-              });
+              return liveTool.execute(
+                args as Parameters<typeof liveTool.execute>[0],
+                createInlineToolExecutionOptions(options),
+              );
             }
           }
 
           return virtualServer.callTool(toolName, args, {
-            abortSignal: options.abortSignal,
+            ...options,
             streamingContext: options.streamingContext ?? undefined,
           });
         }

--- a/packages/agent-sdk/src/mcp/virtual-server.ts
+++ b/packages/agent-sdk/src/mcp/virtual-server.ts
@@ -10,10 +10,29 @@
 import type { Tool, ToolSet } from "ai";
 import { asSchema } from "ai";
 import { formatPluginToolName } from "../tool-names.js";
-import type { StreamingContext, StreamingToolsFactory } from "../types.js";
+import type {
+  ExtendedToolExecutionOptions,
+  StreamingContext,
+  StreamingToolsFactory,
+} from "../types.js";
 import type { MCPToolMetadata } from "./types.js";
 
 const DEFAULT_STREAMING_CONTEXT: StreamingContext = { writer: null };
+
+type ProxyToolCallOptions = Partial<ExtendedToolExecutionOptions> & {
+  streamingContext?: StreamingContext;
+};
+
+function createInlineToolExecutionOptions(options: ProxyToolCallOptions = {}) {
+  const { streamingContext: _streamingContext, ...toolExecutionOptions } = options;
+
+  return {
+    ...toolExecutionOptions,
+    toolCallId: toolExecutionOptions.toolCallId ?? `virtual-${Date.now()}`,
+    messages: toolExecutionOptions.messages ?? [],
+    abortSignal: toolExecutionOptions.abortSignal ?? new AbortController().signal,
+  };
+}
 
 /**
  * Internal wrapper that presents inline plugin tools through the shared discovery interface.
@@ -121,10 +140,7 @@ export class VirtualMCPServer {
   async callTool(
     toolName: string,
     args: unknown,
-    options: {
-      abortSignal?: AbortSignal;
-      streamingContext?: StreamingContext;
-    } = {},
+    options: ProxyToolCallOptions = {},
   ): Promise<unknown> {
     const tool = this.resolveTool(toolName, options.streamingContext);
     if (!tool) {
@@ -135,11 +151,10 @@ export class VirtualMCPServer {
       throw new Error(`Tool '${toolName}' has no execute function`);
     }
 
-    return tool.execute(args as Parameters<typeof tool.execute>[0], {
-      toolCallId: `virtual-${Date.now()}`,
-      messages: [],
-      abortSignal: options.abortSignal ?? new AbortController().signal,
-    });
+    return tool.execute(
+      args as Parameters<typeof tool.execute>[0],
+      createInlineToolExecutionOptions(options),
+    );
   }
 
   /**

--- a/packages/agent-sdk/src/mcp/virtual-server.ts
+++ b/packages/agent-sdk/src/mcp/virtual-server.ts
@@ -10,29 +10,14 @@
 import type { Tool, ToolSet } from "ai";
 import { asSchema } from "ai";
 import { formatPluginToolName } from "../tool-names.js";
-import type {
-  ExtendedToolExecutionOptions,
-  StreamingContext,
-  StreamingToolsFactory,
-} from "../types.js";
+import type { StreamingContext, StreamingToolsFactory } from "../types.js";
+import {
+  createInlineToolExecutionOptions,
+  type ProxyToolCallOptions,
+} from "./execution-options.js";
 import type { MCPToolMetadata } from "./types.js";
 
 const DEFAULT_STREAMING_CONTEXT: StreamingContext = { writer: null };
-
-type ProxyToolCallOptions = Partial<ExtendedToolExecutionOptions> & {
-  streamingContext?: StreamingContext;
-};
-
-function createInlineToolExecutionOptions(options: ProxyToolCallOptions = {}) {
-  const { streamingContext: _streamingContext, ...toolExecutionOptions } = options;
-
-  return {
-    ...toolExecutionOptions,
-    toolCallId: toolExecutionOptions.toolCallId ?? `virtual-${Date.now()}`,
-    messages: toolExecutionOptions.messages ?? [],
-    abortSignal: toolExecutionOptions.abortSignal ?? new AbortController().signal,
-  };
-}
 
 /**
  * Internal wrapper that presents inline plugin tools through the shared discovery interface.
@@ -142,7 +127,7 @@ export class VirtualMCPServer {
     args: unknown,
     options: ProxyToolCallOptions = {},
   ): Promise<unknown> {
-    const tool = this.resolveTool(toolName, options.streamingContext);
+    const tool = this.resolveTool(toolName, options.streamingContext ?? undefined);
     if (!tool) {
       throw new Error(`Tool '${toolName}' not found in inline plugin '${this.name}'`);
     }

--- a/packages/agent-sdk/src/tools/call-tool.ts
+++ b/packages/agent-sdk/src/tools/call-tool.ts
@@ -12,7 +12,11 @@ import type { Tool, ToolExecutionOptions } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
 import type { MCPManager } from "../mcp/manager.js";
-import type { StreamingContext } from "../types.js";
+import type { ExtendedToolExecutionOptions, StreamingContext } from "../types.js";
+
+type ProxyToolExecutionOptions = Partial<ExtendedToolExecutionOptions> & {
+  streamingContext?: StreamingContext | null;
+};
 
 /**
  * Options for creating the call_tool proxy tool.
@@ -110,24 +114,20 @@ export function createCallToolTool(options: CallToolOptions): Tool {
         const metadata = mcpManager.getToolMetadata(tool_name);
         if (metadata) {
           try {
+            const proxyExecutionOptions = execOptions as ProxyToolExecutionOptions | undefined;
             const requestStreamingContext =
-              (
-                execOptions as
-                  | (ToolExecutionOptions & {
-                      streamingContext?: StreamingContext | null;
-                    })
-                  | undefined
-              )?.streamingContext ??
-              streamingContext ??
-              null;
+              proxyExecutionOptions?.streamingContext ?? streamingContext ?? null;
 
             result = await mcpManager.callTool(tool_name, args, {
-              abortSignal: execOptions?.abortSignal,
+              ...proxyExecutionOptions,
               streamingContext: requestStreamingContext,
             });
             await onAfterCall?.(tool_name, args, result);
             return formatResult(tool_name, result);
           } catch (error) {
+            if (isInterruptSignalLike(error)) {
+              throw error;
+            }
             return formatError(tool_name, error);
           }
         }
@@ -160,4 +160,8 @@ function formatResult(toolName: string, result: unknown): string {
 function formatError(toolName: string, error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `Error executing "${toolName}": ${message}`;
+}
+
+function isInterruptSignalLike(error: unknown): boolean {
+  return error instanceof Error && error.name === "InterruptSignal" && "interrupt" in error;
 }

--- a/packages/agent-sdk/tests/e2e/proxy-tool-loading.test.ts
+++ b/packages/agent-sdk/tests/e2e/proxy-tool-loading.test.ts
@@ -12,6 +12,7 @@
 import { tool } from "ai";
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
+import { MemorySaver } from "../../src/checkpointer/memory-saver.js";
 import { createAgent, definePlugin } from "../../src/index.js";
 import { createMockModel, resetMocks } from "../setup.js";
 
@@ -160,6 +161,46 @@ describe("E2E: Proxy Tool Loading", () => {
         execOpts,
       );
       expect(result).toContain("Paid 100");
+    });
+
+    it("lets proxied inline plugin tools initiate interrupt flow via call_tool", async () => {
+      const plugin = definePlugin({
+        name: "approval",
+        tools: {
+          request_approval: tool({
+            description: "Request approval through an interrupt",
+            inputSchema: z.object({}),
+            execute: async (_input, options) =>
+              (options as { interrupt?: (request: unknown) => Promise<unknown> }).interrupt?.({
+                type: "approval",
+                message: "Approve?",
+              }),
+          }),
+        },
+      });
+
+      const agent = createAgent({
+        model: createMockModel(),
+        checkpointer: new MemorySaver(),
+        plugins: [plugin],
+        pluginLoading: "proxy",
+      });
+
+      await expect(
+        agent.getActiveTools().call_tool.execute!(
+          { tool_name: "approval__request_approval", arguments: {} },
+          {
+            ...execOpts,
+            toolCallId: "original-call",
+          },
+        ),
+      ).rejects.toMatchObject({
+        name: "InterruptSignal",
+        interrupt: expect.objectContaining({
+          toolCallId: "original-call",
+          request: { type: "approval", message: "Approve?" },
+        }),
+      });
     });
   });
 

--- a/packages/agent-sdk/tests/mcp-manager.test.ts
+++ b/packages/agent-sdk/tests/mcp-manager.test.ts
@@ -209,6 +209,41 @@ describe("MCPManager", () => {
       expect(result).toBe("Hello, World!");
     });
 
+    it("preserves the original execution context for inline plugin tools", async () => {
+      const abortController = new AbortController();
+      const interrupt = vi.fn();
+      let receivedOptions: Record<string, unknown> | undefined;
+
+      manager.registerPluginTools("test", {
+        inspect: tool({
+          description: "Inspect",
+          inputSchema: z.object({}),
+          execute: async (_input, options) => {
+            receivedOptions = options as Record<string, unknown>;
+            return "ok";
+          },
+        }),
+      });
+
+      await manager.callTool(
+        "test__inspect",
+        {},
+        {
+          toolCallId: "original-call",
+          messages: [],
+          abortSignal: abortController.signal,
+          interrupt,
+        },
+      );
+
+      expect(receivedOptions).toMatchObject({
+        toolCallId: "original-call",
+        messages: [],
+        abortSignal: abortController.signal,
+        interrupt,
+      });
+    });
+
     it("routes inline plugin tools to virtual servers only", async () => {
       const externalCall = vi.fn();
       manager.registerPluginTools("test", {
@@ -394,6 +429,43 @@ describe("MCPManager", () => {
         },
       );
       expect(result2).toBe("rendered(writer=true): <p>world</p>");
+    });
+
+    it("preserves the original execution context for streaming plugin tools", async () => {
+      const abortController = new AbortController();
+      const interrupt = vi.fn();
+      let receivedOptions: Record<string, unknown> | undefined;
+
+      const factory = () => ({
+        inspect: tool({
+          description: "Inspect",
+          inputSchema: z.object({}),
+          execute: async (_input, options) => {
+            receivedOptions = options as Record<string, unknown>;
+            return "ok";
+          },
+        }),
+      });
+
+      manager.registerStreamingPluginTools("ui", factory);
+
+      await manager.callTool(
+        "ui__inspect",
+        {},
+        {
+          toolCallId: "streaming-call",
+          messages: [],
+          abortSignal: abortController.signal,
+          interrupt,
+        },
+      );
+
+      expect(receivedOptions).toMatchObject({
+        toolCallId: "streaming-call",
+        messages: [],
+        abortSignal: abortController.signal,
+        interrupt,
+      });
     });
 
     it("does not leak streaming context between requests", async () => {

--- a/packages/agent-sdk/tests/mcp-virtual-server.test.ts
+++ b/packages/agent-sdk/tests/mcp-virtual-server.test.ts
@@ -56,6 +56,41 @@ describe("VirtualMCPServer", () => {
     expect(result).toBe("Hello, World!");
   });
 
+  it("preserves the original execution context for inline tools", async () => {
+    const abortController = new AbortController();
+    const interrupt = vi.fn();
+    let receivedOptions: Record<string, unknown> | undefined;
+
+    const server = new VirtualMCPServer("my-plugin", {
+      inspect: tool({
+        description: "Inspect execution context",
+        inputSchema: z.object({}),
+        execute: async (_input, options) => {
+          receivedOptions = options as Record<string, unknown>;
+          return "ok";
+        },
+      }),
+    });
+
+    await server.callTool(
+      "inspect",
+      {},
+      {
+        toolCallId: "original-call",
+        messages: [],
+        abortSignal: abortController.signal,
+        interrupt,
+      },
+    );
+
+    expect(receivedOptions).toMatchObject({
+      toolCallId: "original-call",
+      messages: [],
+      abortSignal: abortController.signal,
+      interrupt,
+    });
+  });
+
   it("throws for unknown tool", async () => {
     const server = new VirtualMCPServer("my-plugin", testTools);
     await expect(server.callTool("unknown", {})).rejects.toThrow("Tool 'unknown' not found");


### PR DESCRIPTION
## Summary
- preserve the original tool execution context when `call_tool` proxies to inline plugin tools
- forward `toolCallId`, `interrupt`, `abortSignal`, and other execution fields through `MCPManager` and `VirtualMCPServer`
- let `call_tool` rethrow interrupt signals so proxied tools can initiate interrupt flow instead of returning stringified errors
- add regression coverage for inline proxy execution context and proxied interrupt initiation

## Testing
- `bun x vitest run tests/mcp-virtual-server.test.ts tests/mcp-manager.test.ts tests/e2e/proxy-tool-loading.test.ts`
- `bun run type-check`
- pre-push hook: `biome check .`
- pre-push hook: workspace build/test suite

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline plugin tools routed via the proxy now preserve and forward the original execution context (tool call IDs, interrupt signals and abort handlers), restoring correct interrupt handling and execution control.

* **Tests**
  * Added end-to-end and unit tests to validate execution-context propagation for proxied and virtual inline tool calls.

* **Documentation**
  * Changelog updated to record the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->