### PR TITLE
feat(agent-threads): preserve generic tool metadata in canonical parts

### DIFF
--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of hardcoded canonical fields, keeping transcript storage extensible for app-specific metadata
+- Accumulator now preserves `payload.metadata` on tool-call and tool-result events, merges duplicate tool-call metadata updates, and falls back to pending tool-call metadata when the matching result omits it
+
+### Fixed
+
+- Accumulator payload handling now validates tool event payloads before projecting them into canonical messages, reducing broad type assertions in the ledger reducer while keeping the stream event model open-world
+
 ## [0.1.0-alpha.4] - 2026-04-14
 
 ### Added

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of hardcoded canonical fields, keeping transcript storage extensible for app-specific metadata
-- Accumulator now preserves `payload.metadata` on tool-call and tool-result events, merges duplicate tool-call metadata updates, and falls back to pending tool-call metadata when the matching result omits it
+- `**BREAKING**:` `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of top-level `toolLabel`, `skillName`, and `skillIcon` fields, keeping canonical transcript storage extensible for app-specific metadata
+- `Accumulator` now preserves `payload.metadata` on `tool-call` and `tool-result` events, deep-merges duplicate tool-call metadata updates, and falls back to pending tool-call metadata when the matching result omits it
+- `Accumulator` continues to accept legacy top-level `toolLabel`, `skillName`, and `skillIcon` fields on tool event payloads and normalizes them into `payload.metadata` for backward-compatible ingestion during migration
 
 ### Fixed
 
-- Accumulator payload handling now validates tool event payloads before projecting them into canonical messages, reducing broad type assertions in the ledger reducer while keeping the stream event model open-world
+- `ToolPartMetadata` is now constrained to JSON-serializable values so `ToolCallPart.metadata` and `ToolResultPart.metadata` align with canonical transcript persistence
+- `Accumulator` payload handling now validates tool event payloads before projecting them into canonical messages, reduces broad type assertions in the ledger reducer, and safely filters metadata keys during normalization/merge while keeping the stream event model open-world
 
 ## [0.1.0-alpha.4] - 2026-04-14
 

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -6,6 +6,8 @@ import type {
   CanonicalMessage,
   CanonicalMessageMetadata,
   CanonicalPart,
+  JsonPrimitive,
+  JsonValue,
   ToolCallPart,
   ToolPartMetadata,
 } from "./types.js";
@@ -25,7 +27,7 @@ interface ToolCallEventPayload {
 
 interface ToolResultEventPayload {
   toolCallId: string;
-  toolName: string;
+  toolName?: string;
   output: unknown;
   isError?: boolean;
   metadata?: ToolPartMetadata;
@@ -82,8 +84,70 @@ function getNumber(record: Record<string, unknown>, key: string): number | undef
   return typeof value === "number" ? value : undefined;
 }
 
+function isJsonPrimitive(value: unknown): value is JsonPrimitive {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isUnsafeMetadataKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
+function sanitizeJsonValue(value: unknown): JsonValue | undefined {
+  if (isJsonPrimitive(value)) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const items: JsonValue[] = [];
+    for (const item of value) {
+      const sanitizedItem = sanitizeJsonValue(item);
+      if (sanitizedItem !== undefined) {
+        items.push(sanitizedItem);
+      }
+    }
+    return items;
+  }
+
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  return sanitizeMetadataBag(value);
+}
+
+function sanitizeMetadataBag(record: Record<string, unknown>): ToolPartMetadata | undefined {
+  const metadata: Record<string, JsonValue> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    if (isUnsafeMetadataKey(key)) {
+      continue;
+    }
+
+    const sanitizedValue = sanitizeJsonValue(value);
+    if (sanitizedValue !== undefined) {
+      metadata[key] = sanitizedValue;
+    }
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 function extractLegacyToolMetadata(record: Record<string, unknown>): ToolPartMetadata | undefined {
-  const legacyMetadata: Record<string, unknown> = {};
+  const legacyMetadata: Record<string, JsonValue> = {};
 
   const toolLabel = getString(record, "toolLabel");
   if (toolLabel !== undefined) {
@@ -104,7 +168,9 @@ function extractLegacyToolMetadata(record: Record<string, unknown>): ToolPartMet
 }
 
 function extractToolMetadata(record: Record<string, unknown>): ToolPartMetadata | undefined {
-  const metadata = isRecord(record.metadata) ? { ...record.metadata } : undefined;
+  const metadata = isPlainObject(record.metadata)
+    ? sanitizeMetadataBag(record.metadata)
+    : undefined;
   const legacyMetadata = extractLegacyToolMetadata(record);
 
   if (!metadata && !legacyMetadata) {
@@ -125,10 +191,35 @@ function mergeToolMetadata(
     return undefined;
   }
 
-  return {
-    ...(base ?? {}),
-    ...(override ?? {}),
-  };
+  if (!base) {
+    return sanitizeMetadataBag(override ?? {});
+  }
+
+  if (!override) {
+    return sanitizeMetadataBag(base);
+  }
+
+  const keys = new Set([...Object.keys(base), ...Object.keys(override)]);
+  const metadata: Record<string, JsonValue> = {};
+
+  for (const key of keys) {
+    if (isUnsafeMetadataKey(key)) {
+      continue;
+    }
+
+    const baseValue = base[key];
+    const overrideValue = override[key];
+    const mergedValue =
+      isPlainObject(baseValue) && isPlainObject(overrideValue)
+        ? mergeToolMetadata(sanitizeMetadataBag(baseValue), sanitizeMetadataBag(overrideValue))
+        : (overrideValue ?? baseValue);
+
+    if (mergedValue !== undefined) {
+      metadata[key] = mergedValue;
+    }
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
 function parseToolCallEventPayload(payload: unknown): ToolCallEventPayload | undefined {
@@ -157,7 +248,7 @@ function parseToolResultEventPayload(payload: unknown): ToolResultEventPayload |
 
   const toolCallId = getString(payload, "toolCallId");
   const toolName = getString(payload, "toolName");
-  if (!toolCallId || !toolName || !("output" in payload)) {
+  if (!toolCallId || !("output" in payload)) {
     return undefined;
   }
 

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -7,6 +7,7 @@ import type {
   CanonicalMessageMetadata,
   CanonicalPart,
   ToolCallPart,
+  ToolPartMetadata,
 } from "./types.js";
 import type { IdGenerator } from "./ulid.js";
 import { ulid } from "./ulid.js";
@@ -15,36 +16,220 @@ import { ulid } from "./ulid.js";
 // Event payload shapes
 // ---------------------------------------------------------------------------
 
-interface OptionalToolMeta {
-  toolLabel?: string;
-  skillName?: string;
-  skillIcon?: string;
-}
-
-interface ToolCallEventPayload extends OptionalToolMeta {
+interface ToolCallEventPayload {
   toolCallId: string;
   toolName: string;
   input: unknown;
+  metadata?: ToolPartMetadata;
 }
 
-interface ToolResultEventPayload extends OptionalToolMeta {
+interface ToolResultEventPayload {
   toolCallId: string;
   toolName: string;
   output: unknown;
   isError?: boolean;
+  metadata?: ToolPartMetadata;
 }
 
-interface PendingToolCall extends OptionalToolMeta {
+interface PendingToolCall {
   toolName: string;
   input: unknown;
+  metadata?: ToolPartMetadata;
 }
 
-function extractOptionalToolMeta(payload: OptionalToolMeta): OptionalToolMeta {
+interface FileEventPayload {
+  mimeType: string;
+  url: string;
+  name?: string;
+}
+
+interface StepStartedEventPayload {
+  stepIndex: number;
+}
+
+interface StepFinishedEventPayload {
+  [key: string]: unknown;
+}
+
+interface UserMessageEventPayload {
+  content: string;
+}
+
+interface TextDeltaEventPayload {
+  delta: string;
+}
+
+interface ReasoningEventPayload {
+  text: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getBoolean(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function getNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function extractLegacyToolMetadata(record: Record<string, unknown>): ToolPartMetadata | undefined {
+  const legacyMetadata: Record<string, unknown> = {};
+
+  const toolLabel = getString(record, "toolLabel");
+  if (toolLabel !== undefined) {
+    legacyMetadata.toolLabel = toolLabel;
+  }
+
+  const skillName = getString(record, "skillName");
+  if (skillName !== undefined) {
+    legacyMetadata.skillName = skillName;
+  }
+
+  const skillIcon = getString(record, "skillIcon");
+  if (skillIcon !== undefined) {
+    legacyMetadata.skillIcon = skillIcon;
+  }
+
+  return Object.keys(legacyMetadata).length > 0 ? legacyMetadata : undefined;
+}
+
+function extractToolMetadata(record: Record<string, unknown>): ToolPartMetadata | undefined {
+  const metadata = isRecord(record.metadata) ? { ...record.metadata } : undefined;
+  const legacyMetadata = extractLegacyToolMetadata(record);
+
+  if (!metadata && !legacyMetadata) {
+    return undefined;
+  }
+
   return {
-    ...(typeof payload.toolLabel === "string" ? { toolLabel: payload.toolLabel } : {}),
-    ...(typeof payload.skillName === "string" ? { skillName: payload.skillName } : {}),
-    ...(typeof payload.skillIcon === "string" ? { skillIcon: payload.skillIcon } : {}),
+    ...(legacyMetadata ?? {}),
+    ...(metadata ?? {}),
   };
+}
+
+function mergeToolMetadata(
+  base?: ToolPartMetadata,
+  override?: ToolPartMetadata,
+): ToolPartMetadata | undefined {
+  if (!base && !override) {
+    return undefined;
+  }
+
+  return {
+    ...(base ?? {}),
+    ...(override ?? {}),
+  };
+}
+
+function parseToolCallEventPayload(payload: unknown): ToolCallEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const toolCallId = getString(payload, "toolCallId");
+  const toolName = getString(payload, "toolName");
+  if (!toolCallId || !toolName || !("input" in payload)) {
+    return undefined;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    input: payload.input,
+    metadata: extractToolMetadata(payload),
+  };
+}
+
+function parseToolResultEventPayload(payload: unknown): ToolResultEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const toolCallId = getString(payload, "toolCallId");
+  const toolName = getString(payload, "toolName");
+  if (!toolCallId || !toolName || !("output" in payload)) {
+    return undefined;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    output: payload.output,
+    isError: getBoolean(payload, "isError"),
+    metadata: extractToolMetadata(payload),
+  };
+}
+
+function parseUserMessageEventPayload(payload: unknown): UserMessageEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const content = getString(payload, "content");
+  return content === undefined ? undefined : { content };
+}
+
+function parseTextDeltaEventPayload(payload: unknown): TextDeltaEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const delta = getString(payload, "delta");
+  return delta === undefined ? undefined : { delta };
+}
+
+function parseReasoningEventPayload(payload: unknown): ReasoningEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const text = getString(payload, "text");
+  return text === undefined ? undefined : { text };
+}
+
+function parseFileEventPayload(payload: unknown): FileEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const mimeType = getString(payload, "mimeType");
+  const url = getString(payload, "url");
+  if (!mimeType || !url) {
+    return undefined;
+  }
+
+  return {
+    mimeType,
+    url,
+    name: getString(payload, "name"),
+  };
+}
+
+function parseStepStartedEventPayload(payload: unknown): StepStartedEventPayload | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const stepIndex = getNumber(payload, "stepIndex");
+  return stepIndex === undefined ? undefined : { stepIndex };
+}
+
+function parseStepFinishedEventPayload(payload: unknown): StepFinishedEventPayload | undefined {
+  return isRecord(payload) ? payload : undefined;
+}
+
+function parseErrorEventPayload(payload: unknown): Record<string, unknown> | undefined {
+  return isRecord(payload) ? payload : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,14 +326,21 @@ function createReducer(
 
     switch (kind) {
       case "step-started": {
+        const _p = parseStepStartedEventPayload(payload);
+        if (!_p) {
+          break;
+        }
         flushTextBuffer(state);
         ensureCurrentMessage(state, idGen);
         break;
       }
 
       case "user-message": {
+        const p = parseUserMessageEventPayload(payload);
+        if (!p) {
+          break;
+        }
         commitCurrentMessage(state);
-        const p = payload as { content: string };
         const userMsg = {
           id: idGen(),
           parentMessageId: state.lastMessageId,
@@ -163,25 +355,33 @@ function createReducer(
       }
 
       case "text-delta": {
+        const p = parseTextDeltaEventPayload(payload);
+        if (!p) {
+          break;
+        }
         ensureCurrentMessage(state, idGen);
-        const p = payload as { delta: string };
         state.textBuffer += p.delta;
         break;
       }
 
       case "reasoning": {
+        const p = parseReasoningEventPayload(payload);
+        if (!p) {
+          break;
+        }
         ensureCurrentMessage(state, idGen);
         flushTextBuffer(state);
-        const p = payload as { text: string };
         state.currentMessage!.parts.push({ type: "reasoning", text: p.text });
         break;
       }
 
       case "tool-call": {
+        const p = parseToolCallEventPayload(payload);
+        if (!p) {
+          break;
+        }
         ensureCurrentMessage(state, idGen);
         flushTextBuffer(state);
-        const p = payload as ToolCallEventPayload;
-        const optionalMeta = extractOptionalToolMeta(p);
 
         // Duplicate tool-call events (e.g. async label updates) update the
         // existing part rather than appending a new one.
@@ -190,48 +390,59 @@ function createReducer(
         );
 
         if (existingPartIndex >= 0) {
-          const existing = state.currentMessage!.parts[existingPartIndex] as ToolCallPart;
-          state.currentMessage!.parts[existingPartIndex] = {
+          const existing = state.currentMessage!.parts[existingPartIndex];
+          if (existing?.type !== "tool-call") {
+            break;
+          }
+
+          const nextMetadata = mergeToolMetadata(existing.metadata, p.metadata);
+          const nextPart: ToolCallPart = {
             ...existing,
-            ...optionalMeta,
+            ...(nextMetadata !== undefined ? { metadata: nextMetadata } : {}),
           };
+
+          state.currentMessage!.parts[existingPartIndex] = nextPart;
           const existingPending = state.pendingToolCalls.get(p.toolCallId);
           if (existingPending) {
+            const nextMetadata = mergeToolMetadata(existingPending.metadata, p.metadata);
             state.pendingToolCalls.set(p.toolCallId, {
               ...existingPending,
-              ...optionalMeta,
+              ...(nextMetadata !== undefined ? { metadata: nextMetadata } : {}),
             });
           }
         } else {
-          state.currentMessage!.parts.push({
+          const nextPart: ToolCallPart = {
             type: "tool-call",
             toolCallId: p.toolCallId,
             toolName: p.toolName,
             input: p.input,
-            ...optionalMeta,
-          });
-          state.pendingToolCalls.set(p.toolCallId, {
+            ...(p.metadata !== undefined ? { metadata: p.metadata } : {}),
+          };
+          state.currentMessage!.parts.push(nextPart);
+
+          const pendingToolCall: PendingToolCall = {
             toolName: p.toolName,
             input: p.input,
-            ...optionalMeta,
-          });
+            ...(p.metadata !== undefined ? { metadata: p.metadata } : {}),
+          };
+          state.pendingToolCalls.set(p.toolCallId, pendingToolCall);
         }
         break;
       }
 
       case "tool-result": {
+        const p = parseToolResultEventPayload(payload);
+        if (!p) {
+          break;
+        }
         // Commit the current assistant message first
         commitCurrentMessage(state);
 
-        const p = payload as ToolResultEventPayload;
         const pending = state.pendingToolCalls.get(p.toolCallId);
         const toolName = p.toolName ?? pending?.toolName ?? "unknown";
         state.pendingToolCalls.delete(p.toolCallId);
 
-        const optionalMeta = {
-          ...extractOptionalToolMeta(pending ?? {}),
-          ...extractOptionalToolMeta(p),
-        };
+        const metadata = mergeToolMetadata(pending?.metadata, p.metadata);
 
         const toolMsg: CanonicalMessage = {
           id: idGen(),
@@ -244,7 +455,7 @@ function createReducer(
               toolName,
               output: p.output,
               isError: p.isError ?? false,
-              ...optionalMeta,
+              ...(metadata !== undefined ? { metadata } : {}),
             },
           ],
           createdAt: new Date().toISOString(),
@@ -256,9 +467,12 @@ function createReducer(
       }
 
       case "file": {
+        const p = parseFileEventPayload(payload);
+        if (!p) {
+          break;
+        }
         ensureCurrentMessage(state, idGen);
         flushTextBuffer(state);
-        const p = payload as { mimeType: string; url: string; name?: string };
         state.currentMessage!.parts.push({
           type: "file",
           mimeType: p.mimeType,
@@ -269,9 +483,9 @@ function createReducer(
       }
 
       case "step-finished": {
+        const p = parseStepFinishedEventPayload(payload);
         flushTextBuffer(state);
         if (state.currentMessage) {
-          const p = payload as Record<string, unknown> | undefined;
           if (p) {
             state.currentMessage.metadata = { ...state.currentMessage.metadata, stepFinish: p };
           }
@@ -281,8 +495,11 @@ function createReducer(
       }
 
       case "error": {
+        const p = parseErrorEventPayload(payload);
+        if (!p) {
+          break;
+        }
         ensureCurrentMessage(state, idGen);
-        const p = payload as Record<string, unknown>;
         state.currentMessage!.metadata = { ...state.currentMessage!.metadata, error: p };
         break;
       }

--- a/packages/agent-threads/src/ledger/types.ts
+++ b/packages/agent-threads/src/ledger/types.ts
@@ -29,13 +29,43 @@ export interface ReasoningPart {
 }
 
 /**
+ * JSON primitive values.
+ *
+ * @category Types
+ */
+export type JsonPrimitive = string | number | boolean | null;
+
+/**
+ * A JSON-serializable value.
+ *
+ * @category Types
+ */
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+/**
+ * A JSON-serializable object.
+ *
+ * @category Types
+ */
+export interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+/**
+ * A JSON-serializable array.
+ *
+ * @category Types
+ */
+export type JsonArray = readonly JsonValue[];
+
+/**
  * Additional JSON-compatible metadata preserved on tool call and tool result parts.
  *
  * @category Types
  */
 export interface ToolPartMetadata {
   /** Additional JSON-compatible metadata associated with a tool part */
-  readonly [key: string]: unknown;
+  readonly [key: string]: JsonValue;
 }
 
 /**

--- a/packages/agent-threads/src/ledger/types.ts
+++ b/packages/agent-threads/src/ledger/types.ts
@@ -29,6 +29,16 @@ export interface ReasoningPart {
 }
 
 /**
+ * Additional JSON-compatible metadata preserved on tool call and tool result parts.
+ *
+ * @category Types
+ */
+export interface ToolPartMetadata {
+  /** Additional JSON-compatible metadata associated with a tool part */
+  readonly [key: string]: unknown;
+}
+
+/**
  * A tool invocation recorded within a canonical message.
  *
  * @category Types
@@ -38,12 +48,8 @@ export interface ToolCallPart {
   readonly toolCallId: string;
   readonly toolName: string;
   readonly input: unknown;
-  /** Human-readable label describing the tool action (e.g. "Read file: utils.ts") */
-  readonly toolLabel?: string;
-  /** Name of the skill that owns this tool */
-  readonly skillName?: string;
-  /** Icon identifier for the skill */
-  readonly skillIcon?: string;
+  /** Additional JSON-compatible metadata preserved from the tool event payload */
+  readonly metadata?: ToolPartMetadata;
 }
 
 /**
@@ -57,12 +63,8 @@ export interface ToolResultPart {
   readonly toolName: string;
   readonly output: unknown;
   readonly isError: boolean;
-  /** Human-readable label describing the tool result (e.g. "Read file: utils.ts") */
-  readonly toolLabel?: string;
-  /** Name of the skill that owns this tool */
-  readonly skillName?: string;
-  /** Icon identifier for the skill */
-  readonly skillIcon?: string;
+  /** Additional JSON-compatible metadata preserved from the tool event payload */
+  readonly metadata?: ToolPartMetadata;
 }
 
 /**

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -561,6 +561,61 @@ describe("Accumulator", () => {
       });
     });
 
+    it("deep-merges nested metadata on duplicate tool-call updates", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              ui: {
+                label: "Searching your inbox",
+                icon: "mail",
+              },
+              provenance: {
+                skillId: "skl-email",
+              },
+            },
+          },
+        },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              ui: {
+                label: "Found 3 invoices",
+              },
+            },
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      expect(messages[0]!.parts[0]).toEqual({
+        type: "tool-call",
+        toolCallId: "tc-1",
+        toolName: "search_emails",
+        input: { query: "invoice" },
+        metadata: {
+          ui: {
+            label: "Found 3 invoices",
+            icon: "mail",
+          },
+          provenance: {
+            skillId: "skl-email",
+          },
+        },
+      });
+    });
+
     it("preserves metadata on tool-result parts when isError is true", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([
@@ -652,6 +707,77 @@ describe("Accumulator", () => {
           skillIcon: "folder",
         },
       });
+    });
+
+    it("falls back to pending tool-call toolName when tool-result omits it", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "read_file",
+            input: { path: "utils.ts" },
+            metadata: {
+              toolLabel: "Read file: utils.ts",
+            },
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            output: "file contents",
+            isError: false,
+          },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      expect(messages[1]!.parts[0]).toEqual({
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "read_file",
+        output: "file contents",
+        isError: false,
+        metadata: {
+          toolLabel: "Read file: utils.ts",
+        },
+      });
+    });
+
+    it("filters unsafe metadata keys during normalization", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "web_search",
+            input: { query: "weather" },
+            metadata: {
+              toolLabel: "Searching the web...",
+              ["__proto__"]: { polluted: true },
+            },
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      expect(messages[0]!.parts[0]).toEqual({
+        type: "tool-call",
+        toolCallId: "tc-1",
+        toolName: "web_search",
+        input: { query: "weather" },
+        metadata: {
+          toolLabel: "Searching the web...",
+        },
+      });
+      expect(Object.prototype).not.toHaveProperty("polluted");
     });
 
     it("propagates duplicate tool-call metadata updates to the eventual tool-result", () => {

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -287,7 +287,7 @@ describe("Accumulator", () => {
   });
 
   describe("tool metadata", () => {
-    it("preserves toolLabel on tool-call parts", () => {
+    it("preserves generic metadata on tool-call and tool-result parts", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([
         { kind: "step-started", payload: { stepIndex: 0 } },
@@ -295,9 +295,13 @@ describe("Accumulator", () => {
           kind: "tool-call",
           payload: {
             toolCallId: "tc-1",
-            toolName: "read_file",
-            input: { path: "utils.ts" },
-            toolLabel: "Read file: utils.ts",
+            toolName: "gmail_send",
+            input: { subject: "Hello" },
+            metadata: {
+              toolLabel: "Send email",
+              skillId: "skl-gmail",
+              componentId: "cmp-compose",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -305,54 +309,14 @@ describe("Accumulator", () => {
           kind: "tool-result",
           payload: {
             toolCallId: "tc-1",
-            toolName: "read_file",
-            output: "file contents",
-            isError: false,
-            toolLabel: "Read file: utils.ts",
-          },
-        },
-      ]);
-
-      const messages = accumulateEvents(storedEvents, idGen);
-      const callPart = messages[0]!.parts[0]!;
-      expect(callPart).toMatchObject({
-        type: "tool-call",
-        toolCallId: "tc-1",
-        toolLabel: "Read file: utils.ts",
-      });
-
-      const resultPart = messages[1]!.parts[0]!;
-      expect(resultPart).toMatchObject({
-        type: "tool-result",
-        toolCallId: "tc-1",
-        toolLabel: "Read file: utils.ts",
-      });
-    });
-
-    it("preserves skillName and skillIcon on tool parts", () => {
-      const idGen = createCounterIdGenerator("msg");
-      const storedEvents = wrapEvents([
-        { kind: "step-started", payload: { stepIndex: 0 } },
-        {
-          kind: "tool-call",
-          payload: {
-            toolCallId: "tc-1",
-            toolName: "send_email",
-            input: { to: "user@example.com" },
-            skillName: "Email",
-            skillIcon: "mail",
-          },
-        },
-        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
-        {
-          kind: "tool-result",
-          payload: {
-            toolCallId: "tc-1",
-            toolName: "send_email",
+            toolName: "gmail_send",
             output: "sent",
             isError: false,
-            skillName: "Email",
-            skillIcon: "mail",
+            metadata: {
+              toolLabel: "Sent email",
+              skillId: "skl-gmail",
+              componentId: "cmp-compose",
+            },
           },
         },
       ]);
@@ -361,19 +325,77 @@ describe("Accumulator", () => {
       const callPart = messages[0]!.parts[0]!;
       expect(callPart).toMatchObject({
         type: "tool-call",
-        skillName: "Email",
-        skillIcon: "mail",
+        toolCallId: "tc-1",
+        metadata: {
+          toolLabel: "Send email",
+          skillId: "skl-gmail",
+          componentId: "cmp-compose",
+        },
       });
 
       const resultPart = messages[1]!.parts[0]!;
       expect(resultPart).toMatchObject({
         type: "tool-result",
-        skillName: "Email",
-        skillIcon: "mail",
+        toolCallId: "tc-1",
+        metadata: {
+          toolLabel: "Sent email",
+          skillId: "skl-gmail",
+          componentId: "cmp-compose",
+        },
       });
     });
 
-    it("omits metadata fields when not present in event payload", () => {
+    it("normalizes legacy top-level metadata fields into metadata for compatibility", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            toolLabel: "Searching inbox",
+            skillName: "Email",
+            skillIcon: "mail",
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            output: "ok",
+            isError: false,
+            toolLabel: "Found 3 invoices",
+          },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const callPart = messages[0]!.parts[0]!;
+      expect(callPart).toMatchObject({
+        type: "tool-call",
+        metadata: {
+          toolLabel: "Searching inbox",
+          skillName: "Email",
+          skillIcon: "mail",
+        },
+      });
+
+      const resultPart = messages[1]!.parts[0]!;
+      expect(resultPart).toMatchObject({
+        type: "tool-result",
+        metadata: {
+          toolLabel: "Found 3 invoices",
+          skillName: "Email",
+          skillIcon: "mail",
+        },
+      });
+    });
+
+    it("omits metadata when not present in event payload", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([
         { kind: "step-started", payload: { stepIndex: 0 } },
@@ -407,7 +429,7 @@ describe("Accumulator", () => {
       });
     });
 
-    it("updates toolLabel on duplicate tool-call events (async LLM label)", () => {
+    it("updates metadata on duplicate tool-call events", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([
         { kind: "step-started", payload: { stepIndex: 0 } },
@@ -417,7 +439,10 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "web_search",
             input: { query: "weather" },
-            toolLabel: "Searching the web...",
+            metadata: {
+              toolLabel: "Searching the web...",
+              skillId: "skl-search",
+            },
           },
         },
         // Second tool-call event with updated LLM-generated label
@@ -427,7 +452,9 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "web_search",
             input: { query: "weather" },
-            toolLabel: "Looking up the current weather forecast",
+            metadata: {
+              toolLabel: "Looking up the current weather forecast",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -439,7 +466,10 @@ describe("Accumulator", () => {
         type: "tool-call",
         toolCallId: "tc-1",
         toolName: "web_search",
-        toolLabel: "Looking up the current weather forecast",
+        metadata: {
+          toolLabel: "Looking up the current weather forecast",
+          skillId: "skl-search",
+        },
       });
     });
 
@@ -462,8 +492,10 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "bash",
             input: { command: "ls" },
-            toolLabel: "Listing directory contents",
-            skillName: "Shell",
+            metadata: {
+              toolLabel: "Listing directory contents",
+              skillName: "Shell",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -474,8 +506,10 @@ describe("Accumulator", () => {
       expect(messages[0]!.parts[0]).toMatchObject({
         type: "tool-call",
         toolCallId: "tc-1",
-        toolLabel: "Listing directory contents",
-        skillName: "Shell",
+        metadata: {
+          toolLabel: "Listing directory contents",
+          skillName: "Shell",
+        },
       });
     });
 
@@ -489,9 +523,11 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "search_emails",
             input: { query: "invoice" },
-            toolLabel: "Searching your inbox",
-            skillName: "Email",
-            skillIcon: "mail",
+            metadata: {
+              toolLabel: "Searching your inbox",
+              skillName: "Email",
+              skillIcon: "mail",
+            },
           },
         },
         // Later duplicate carries only an updated label; skillName/skillIcon
@@ -502,7 +538,9 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "search_emails",
             input: { query: "invoice" },
-            toolLabel: "Found 3 invoices",
+            metadata: {
+              toolLabel: "Found 3 invoices",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -515,9 +553,11 @@ describe("Accumulator", () => {
         toolCallId: "tc-1",
         toolName: "search_emails",
         input: { query: "invoice" },
-        toolLabel: "Found 3 invoices",
-        skillName: "Email",
-        skillIcon: "mail",
+        metadata: {
+          toolLabel: "Found 3 invoices",
+          skillName: "Email",
+          skillIcon: "mail",
+        },
       });
     });
 
@@ -531,7 +571,9 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "read_file",
             input: { path: "missing.ts" },
-            toolLabel: "Read file: missing.ts",
+            metadata: {
+              toolLabel: "Read file: missing.ts",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -542,9 +584,11 @@ describe("Accumulator", () => {
             toolName: "read_file",
             output: "ENOENT: no such file",
             isError: true,
-            toolLabel: "Failed to read file: missing.ts",
-            skillName: "Filesystem",
-            skillIcon: "folder",
+            metadata: {
+              toolLabel: "Failed to read file: missing.ts",
+              skillName: "Filesystem",
+              skillIcon: "folder",
+            },
           },
         },
       ]);
@@ -557,9 +601,11 @@ describe("Accumulator", () => {
         toolName: "read_file",
         output: "ENOENT: no such file",
         isError: true,
-        toolLabel: "Failed to read file: missing.ts",
-        skillName: "Filesystem",
-        skillIcon: "folder",
+        metadata: {
+          toolLabel: "Failed to read file: missing.ts",
+          skillName: "Filesystem",
+          skillIcon: "folder",
+        },
       });
     });
 
@@ -573,9 +619,11 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "read_file",
             input: { path: "utils.ts" },
-            toolLabel: "Read file: utils.ts",
-            skillName: "Filesystem",
-            skillIcon: "folder",
+            metadata: {
+              toolLabel: "Read file: utils.ts",
+              skillName: "Filesystem",
+              skillIcon: "folder",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -598,9 +646,11 @@ describe("Accumulator", () => {
         toolName: "read_file",
         output: "file contents",
         isError: false,
-        toolLabel: "Read file: utils.ts",
-        skillName: "Filesystem",
-        skillIcon: "folder",
+        metadata: {
+          toolLabel: "Read file: utils.ts",
+          skillName: "Filesystem",
+          skillIcon: "folder",
+        },
       });
     });
 
@@ -614,9 +664,11 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "search_emails",
             input: { query: "invoice" },
-            toolLabel: "Searching your inbox",
-            skillName: "Email",
-            skillIcon: "mail",
+            metadata: {
+              toolLabel: "Searching your inbox",
+              skillName: "Email",
+              skillIcon: "mail",
+            },
           },
         },
         {
@@ -625,7 +677,9 @@ describe("Accumulator", () => {
             toolCallId: "tc-1",
             toolName: "search_emails",
             input: { query: "invoice" },
-            toolLabel: "Found 3 invoices",
+            metadata: {
+              toolLabel: "Found 3 invoices",
+            },
           },
         },
         { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
@@ -648,9 +702,11 @@ describe("Accumulator", () => {
         toolName: "search_emails",
         output: "Found 3 emails",
         isError: false,
-        toolLabel: "Found 3 invoices",
-        skillName: "Email",
-        skillIcon: "mail",
+        metadata: {
+          toolLabel: "Found 3 invoices",
+          skillName: "Email",
+          skillIcon: "mail",
+        },
       });
     });
   });

--- a/packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata-fallback.json
+++ b/packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata-fallback.json
@@ -1,5 +1,5 @@
 {
-  "description": "Tool result reuses metadata captured on earlier tool-call events when the result payload omits it",
+  "description": "Tool result reuses generic metadata captured on earlier tool-call events when the result payload omits it",
   "events": [
     { "kind": "step-started", "payload": { "stepIndex": 0 } },
     { "kind": "text-delta", "payload": { "delta": "Let me search your inbox." } },
@@ -9,9 +9,11 @@
         "toolCallId": "tc-1",
         "toolName": "search_emails",
         "input": { "query": "invoice" },
-        "toolLabel": "Searching your inbox",
-        "skillName": "Email",
-        "skillIcon": "mail"
+        "metadata": {
+          "toolLabel": "Searching your inbox",
+          "skillName": "Email",
+          "skillIcon": "mail"
+        }
       }
     },
     {
@@ -20,7 +22,9 @@
         "toolCallId": "tc-1",
         "toolName": "search_emails",
         "input": { "query": "invoice" },
-        "toolLabel": "Found 3 invoices"
+        "metadata": {
+          "toolLabel": "Found 3 invoices"
+        }
       }
     },
     { "kind": "step-finished", "payload": { "stepIndex": 0, "finishReason": "tool-calls" } },
@@ -44,9 +48,11 @@
           "toolCallId": "tc-1",
           "toolName": "search_emails",
           "input": { "query": "invoice" },
-          "toolLabel": "Found 3 invoices",
-          "skillName": "Email",
-          "skillIcon": "mail"
+          "metadata": {
+            "toolLabel": "Found 3 invoices",
+            "skillName": "Email",
+            "skillIcon": "mail"
+          }
         }
       ]
     },
@@ -59,9 +65,11 @@
           "toolName": "search_emails",
           "output": "Found 3 emails",
           "isError": false,
-          "toolLabel": "Found 3 invoices",
-          "skillName": "Email",
-          "skillIcon": "mail"
+          "metadata": {
+            "toolLabel": "Found 3 invoices",
+            "skillName": "Email",
+            "skillIcon": "mail"
+          }
         }
       ]
     }

--- a/packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata.json
+++ b/packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Tool call and result with metadata (toolLabel, skillName, skillIcon)",
+  "description": "Tool call and result with generic metadata bags",
   "events": [
     { "kind": "step-started", "payload": { "stepIndex": 0 } },
     { "kind": "text-delta", "payload": { "delta": "Let me search your email." } },
@@ -9,9 +9,11 @@
         "toolCallId": "tc-1",
         "toolName": "search_emails",
         "input": { "query": "invoice" },
-        "toolLabel": "Searching emails...",
-        "skillName": "Email",
-        "skillIcon": "mail"
+        "metadata": {
+          "toolLabel": "Searching emails...",
+          "skillName": "Email",
+          "skillIcon": "mail"
+        }
       }
     },
     {
@@ -20,7 +22,9 @@
         "toolCallId": "tc-1",
         "toolName": "search_emails",
         "input": { "query": "invoice" },
-        "toolLabel": "Searching your inbox for invoices"
+        "metadata": {
+          "toolLabel": "Searching your inbox for invoices"
+        }
       }
     },
     { "kind": "step-finished", "payload": { "stepIndex": 0, "finishReason": "tool-calls" } },
@@ -31,9 +35,11 @@
         "toolName": "search_emails",
         "output": "Found 3 emails",
         "isError": false,
-        "toolLabel": "Found 3 emails about invoices",
-        "skillName": "Email",
-        "skillIcon": "mail"
+        "metadata": {
+          "toolLabel": "Found 3 emails about invoices",
+          "skillName": "Email",
+          "skillIcon": "mail"
+        }
       }
     },
     { "kind": "step-started", "payload": { "stepIndex": 1 } },
@@ -50,9 +56,11 @@
           "toolCallId": "tc-1",
           "toolName": "search_emails",
           "input": { "query": "invoice" },
-          "toolLabel": "Searching your inbox for invoices",
-          "skillName": "Email",
-          "skillIcon": "mail"
+          "metadata": {
+            "toolLabel": "Searching your inbox for invoices",
+            "skillName": "Email",
+            "skillIcon": "mail"
+          }
         }
       ]
     },
@@ -65,9 +73,11 @@
           "toolName": "search_emails",
           "output": "Found 3 emails",
           "isError": false,
-          "toolLabel": "Found 3 emails about invoices",
-          "skillName": "Email",
-          "skillIcon": "mail"
+          "metadata": {
+            "toolLabel": "Found 3 emails about invoices",
+            "skillName": "Email",
+            "skillIcon": "mail"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

- replace hardcoded canonical tool metadata fields with a generic `metadata` bag on `ToolCallPart` and `ToolResultPart`
- preserve `payload.metadata` through the accumulator, including duplicate `tool-call` updates and fallback from pending `tool-call` metadata onto `tool-result`
- tighten accumulator payload parsing so the reducer validates event shapes instead of relying on broad casts
- keep compatibility with existing producers by normalizing legacy top-level `toolLabel`, `skillName`, and `skillIcon` fields into `metadata`

## Why

PR #115 surfaced a real issue in `agent-threads`: extra tool payload fields were being dropped when stream events were projected into canonical messages.

The more durable fix is to keep `agent-threads` generic rather than adding more app-specific top-level fields like `skillId` / `componentId`. A generic `metadata` bag gives downstream apps somewhere stable to store provenance and UI state without needing to keep expanding the canonical schema.

## Test plan

- [x] `bun run --filter "@lleverage-ai/agent-threads" type-check`
- [x] `bun run --filter "@lleverage-ai/agent-threads" build`
- [x] `bun run --filter "@lleverage-ai/agent-threads" test`
- [x] `bun x vitest run packages/agent-threads/tests/ledger/accumulator.test.ts`
- [x] `bun x biome check packages/agent-threads/src/ledger/types.ts packages/agent-threads/src/ledger/accumulator.ts packages/agent-threads/tests/ledger/accumulator.test.ts packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata.json packages/agent-threads/tests/ledger/fixtures/golden/tool-metadata-fallback.json packages/agent-threads/CHANGELOG.md`
- [x] pre-push hook: `biome check .`
- [x] pre-push hook: `bun run --filter "@lleverage-ai/agent-threads" build && bun run --filter "@lleverage-ai/agent-threads" test && bun run --filter "@lleverage-ai/agent-sdk" test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Tool parts now carry a single JSON-serialisable metadata bag instead of fixed top-level label fields, with legacy payloads normalised into this metadata.

* **Fixed**
  * Improved validation and safer merging of tool event payloads so metadata is preserved and merged correctly across calls and results; unsafe keys are filtered.

* **Documentation**
  * Changelog updated to describe the metadata and accumulator behaviour.

* **Tests**
  * Test fixtures and suites updated to reflect metadata consolidation and merging behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->