### PR TITLE
chore(release): prepare agent-sdk and agent-threads alpha releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-04-15
+
 ### Fixed
 
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
@@ -276,7 +278,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error types and graceful degradation utilities
 - Testing utilities via `@lleverage-ai/agent-sdk/testing`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.1...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.2...HEAD
+[0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.1...agent-sdk@0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.0.14...agent-sdk@0.1.0-alpha.1
 [0.0.14]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.13...agent-sdk@0.0.14
 [0.0.13]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...v0.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.2] - 2026-04-15
-
 ### Fixed
 
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
@@ -278,8 +276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error types and graceful degradation utilities
 - Testing utilities via `@lleverage-ai/agent-sdk/testing`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.2...HEAD
-[0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.1...agent-sdk@0.1.0-alpha.2
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.1.0-alpha.1...HEAD
 [0.1.0-alpha.1]: https://github.com/lleverage-ai/agent-sdk/compare/agent-sdk@0.0.14...agent-sdk@0.1.0-alpha.1
 [0.0.14]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.13...agent-sdk@0.0.14
 [0.0.13]: https://github.com/lleverage-ai/agent-sdk/compare/v0.0.12...v0.0.13

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5] - 2026-04-15
-
 ### Changed
 
-- `**BREAKING**:` `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of top-level `toolLabel`, `skillName`, and `skillIcon` fields, keeping canonical transcript storage extensible for app-specific metadata
+- **BREAKING**: `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of top-level `toolLabel`, `skillName`, and `skillIcon` fields, keeping canonical transcript storage extensible for app-specific metadata
 - `Accumulator` now preserves `payload.metadata` on `tool-call` and `tool-result` events, deep-merges duplicate tool-call metadata updates, and falls back to pending tool-call metadata when the matching result omits it
 - `Accumulator` continues to accept legacy top-level `toolLabel`, `skillName`, and `skillIcon` fields on tool event payloads and normalizes them into `payload.metadata` for backward-compatible ingestion during migration
 
@@ -66,8 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ledger layer: canonical message schema, `RunManager`, accumulator, reconciliation, `FullContextBuilder`, ledger stores (`InMemoryLedgerStore`, `SQLiteLedgerStore`)
 - Subpath exports for granular imports: `./stream`, `./ledger`, `./server`, `./client`, `./stores/*`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.5...HEAD
-[0.1.0-alpha.5]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.4...agent-threads@0.1.0-alpha.5
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.4...HEAD
 [0.1.0-alpha.4]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.3...agent-threads@0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.2...agent-threads@0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.1...agent-threads@0.1.0-alpha.2

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] - 2026-04-15
+
 ### Changed
 
 - `**BREAKING**:` `ToolCallPart` and `ToolResultPart` now expose a generic `metadata` bag for tool provenance and UI state instead of top-level `toolLabel`, `skillName`, and `skillIcon` fields, keeping canonical transcript storage extensible for app-specific metadata
@@ -64,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ledger layer: canonical message schema, `RunManager`, accumulator, reconciliation, `FullContextBuilder`, ledger stores (`InMemoryLedgerStore`, `SQLiteLedgerStore`)
 - Subpath exports for granular imports: `./stream`, `./ledger`, `./server`, `./client`, `./stores/*`
 
-[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.4...HEAD
+[Unreleased]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.5...HEAD
+[0.1.0-alpha.5]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.4...agent-threads@0.1.0-alpha.5
 [0.1.0-alpha.4]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.3...agent-threads@0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.2...agent-threads@0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/lleverage-ai/agent-sdk/compare/agent-threads@0.1.0-alpha.1...agent-threads@0.1.0-alpha.2

--- a/packages/agent-threads/package.json
+++ b/packages/agent-threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-threads",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Event transport, replay, and durable transcripts for AI agent conversations",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `@lleverage-ai/agent-sdk` from `0.1.0-alpha.1` to `0.1.0-alpha.2`
- bump `@lleverage-ai/agent-threads` from `0.1.0-alpha.4` to `0.1.0-alpha.5`
- promote current unreleased changelog entries into dated release sections for both packages

## Verification
- `biome check .` (run by push hook; reported only a schema-version info message)
- `bun run test` (run by push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped versions for agent-sdk and agent-threads packages.
  * Updated documentation formatting in changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->