### PR TITLE
feat(agent-sdk): add execution telemetry to observability hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Execution telemetry follow-up runs, cached responses, tracing spans, and rate-limit metrics now preserve accurate model attribution and clean up request-scoped observability state
 - Observability metrics now avoid negative in-progress request gauges and token overcounts when lifecycle starts or usage fields are absent
 - Background follow-up tool hooks now receive execution telemetry, and observability metric timing state is pruned for abandoned lifecycle pairs
+- Cached generation results now receive fresh per-request telemetry, and request metrics stay open across retryable generation failures until the retry decision is terminal
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
 
 ## [0.1.0-alpha.1] - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Execution telemetry follow-up runs, cached responses, tracing spans, and rate-limit metrics now preserve accurate model attribution and clean up request-scoped observability state
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
 
 ## [0.1.0-alpha.1] - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Execution telemetry follow-up runs, cached responses, tracing spans, and rate-limit metrics now preserve accurate model attribution and clean up request-scoped observability state
 - Observability metrics now avoid negative in-progress request gauges and token overcounts when lifecycle starts or usage fields are absent
+- Background follow-up tool hooks now receive execution telemetry, and observability metric timing state is pruned for abandoned lifecycle pairs
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
 
 ## [0.1.0-alpha.1] - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Observability metrics now avoid negative in-progress request gauges and token overcounts when lifecycle starts or usage fields are absent
 - Background follow-up tool hooks now receive execution telemetry, and observability metric timing state is pruned for abandoned lifecycle pairs
 - Cached generation results now receive fresh per-request telemetry, and request metrics stay open across retryable generation failures until the retry decision is terminal
+- Cached `PostGenerate` hooks now apply updated results, resume-time tool execution receives telemetry, and in-progress metrics reuse their original gauge labels when closing
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
 
 ## [0.1.0-alpha.1] - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- First-class execution telemetry in `@lleverage-ai/agent-sdk`: generation results and hook inputs now carry `telemetry` metadata with `runId`, `threadId`, requested/response model identity, usage, and timing data for reliable per-run correlation
+- Built-in tracing hooks via `createTracingHooks()`, including generation, tool, compaction, and subagent spans with execution correlation metadata
+
+### Changed
+
+- `createObservabilityPreset()` now auto-wires metrics and tracing hooks in addition to logging hooks, so enabling observability also instruments agent requests, tools, compaction, retries, and subagent lifecycle events by default
+- Built-in logging, audit, metrics, and observability event hooks now record resolved model identity and execution correlation metadata emitted by the SDK runtime instead of relying on app-level labels
+- Checkpointed interrupt/resume flows now persist SDK-generated `runId` metadata alongside thread state so resumed executions keep stable correlation IDs across interrupts
+
 ### Fixed
 
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Execution telemetry follow-up runs, cached responses, tracing spans, and rate-limit metrics now preserve accurate model attribution and clean up request-scoped observability state
+- Observability metrics now avoid negative in-progress request gauges and token overcounts when lifecycle starts or usage fields are absent
 - `call_tool` now preserves the original execution context for proxied inline plugin tools, forwarding the incoming `toolCallId`, `interrupt`, and abort context instead of replacing them with synthetic proxy values (#117)
 
 ## [0.1.0-alpha.1] - 2026-04-14

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -75,7 +75,7 @@ const registry = createMetricsRegistry({
 
 const metrics = createAgentMetrics(registry);
 metrics.requestsTotal.inc({ model: "claude-3" });
-metrics.latencyHistogram.observe({ model: "claude-3" }, 1500);
+metrics.requestDurationMs.observe(1500, { model: "claude-3" });
 ```
 
 ### Built-in Agent Metrics
@@ -84,9 +84,11 @@ metrics.latencyHistogram.observe({ model: "claude-3" }, 1500);
 |--------|------|-------------|
 | `requestsTotal` | Counter | Total number of requests |
 | `errorsTotal` | Counter | Total number of errors |
-| `latencyHistogram` | Histogram | Request latency distribution |
-| `tokensUsed` | Counter | Total tokens consumed |
+| `requestDurationMs` | Histogram | Request latency distribution |
+| `tokensTotal` | Counter | Total tokens consumed |
 | `toolCallsTotal` | Counter | Total tool invocations |
+| `toolDurationMs` | Histogram | Tool latency distribution |
+| `streamTimeToFirstTokenMs` | Histogram | Stream time-to-first-token |
 
 ### Custom Metrics
 
@@ -279,18 +281,21 @@ const mcpEvents = store.getByType("MCPConnectionFailed");
 One-line setup for common observability needs:
 
 ```typescript
-import { createObservabilityPreset } from "@lleverage-ai/agent-sdk";
+import {
+  createConsoleTransport,
+  createConsoleSpanExporter,
+  createObservabilityPreset,
+} from "@lleverage-ai/agent-sdk";
 
 const { logger, metrics, tracer, hooks } = createObservabilityPreset({
   name: "my-agent",
-  logLevel: "info",
   enableMetrics: true,
   enableTracing: true,
-  exporters: {
-    logs: [createConsoleTransport()],
-    metrics: [createPrometheusExporter({ port: 9090 })],
-    traces: [createJaegerExporter({ endpoint: "http://jaeger:14268" })],
+  loggerOptions: {
+    level: "info",
+    transports: [createConsoleTransport()],
   },
+  spanExporters: [createConsoleSpanExporter()],
 });
 
 const agent = createAgent({
@@ -298,6 +303,26 @@ const agent = createAgent({
   hooks,
 });
 ```
+
+When `enableHooks` is left on, the preset now wires logging, metrics, and tracing hooks together. That means request counters, latency histograms, tool metrics, and spans are emitted automatically without extra manual hook registration.
+
+## Execution Metadata
+
+Generation results and generation/tool/subagent hook inputs now include SDK-generated execution metadata:
+
+```typescript
+const result = await agent.generate({
+  prompt: "Summarize this",
+  threadId: "thread_123",
+});
+
+console.log(result.telemetry?.threadId); // "thread_123"
+console.log(result.telemetry?.runId); // Stable per-run ID
+console.log(result.telemetry?.requestedModel?.modelId);
+console.log(result.telemetry?.responseModelId);
+```
+
+This metadata is intended for correlation in logs, traces, audit events, and event stores. `threadId` and `runId` are intentionally not added as built-in metric labels because they are high-cardinality dimensions.
 
 ## Logging Hooks
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -74,7 +74,7 @@ const registry = createMetricsRegistry({
 });
 
 const metrics = createAgentMetrics(registry);
-metrics.requestsTotal.inc({ model: "claude-3" });
+metrics.requestsTotal.inc(1, { model: "claude-3" });
 metrics.requestDurationMs.observe(1500, { model: "claude-3" });
 ```
 
@@ -318,8 +318,8 @@ const result = await agent.generate({
 
 console.log(result.telemetry?.threadId); // "thread_123"
 console.log(result.telemetry?.runId); // Stable per-run ID
-console.log(result.telemetry?.requestedModel?.modelId);
-console.log(result.telemetry?.responseModelId);
+console.log(result.telemetry?.requestedModelId);
+console.log(result.telemetry?.modelId);
 ```
 
 This metadata is intended for correlation in logs, traces, audit events, and event stores. `threadId` and `runId` are intentionally not added as built-in metric labels because they are high-cardinality dimensions.

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -54,6 +54,7 @@ console.log(result.text);
 - Plugins that bundle tools, skills, hooks, and MCP integrations
 - Deferred discovery and proxy loading with `search_tools` and `call_tool`
 - Subagents, teams, memory, observability, middleware, and security utilities
+- SDK-level execution telemetry with stable `runId` / `threadId` correlation and resolved model metadata on results, hooks, logs, and traces
 
 ## When To Use This Package
 

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -3403,9 +3403,15 @@ export function createAgent(options: AgentOptions): Agent {
                     followUpRequestOptions,
                     (requestOptions, currentModel) => {
                       const followUpMessages = requestOptions.messages ?? [];
+                      const followUpTelemetry = buildExecutionTelemetryFromIds({
+                        runId: requestOptions._runId ?? executionBaseTelemetry.runId,
+                        threadId: requestOptions.threadId,
+                        requestedModel: currentModel,
+                      });
                       const followUpTools = applyToolHooks(
                         addTaskToolIfConfigured(getActiveToolSet(requestOptions.threadId)),
                         requestOptions.threadId,
+                        followUpTelemetry,
                       );
                       const activeFollowUpTools = wrapToolsWithSignalCatching(
                         followUpTools,
@@ -4097,12 +4103,18 @@ export function createAgent(options: AgentOptions): Agent {
                     followUpRequestOptions,
                     (requestOptions, currentModel) => {
                       const followUpMessages = requestOptions.messages ?? [];
+                      const followUpTelemetry = buildExecutionTelemetryFromIds({
+                        runId: requestOptions._runId ?? executionBaseTelemetry.runId,
+                        threadId: requestOptions.threadId,
+                        requestedModel: currentModel,
+                      });
                       const hookedFollowUpTools = applyToolHooks(
                         addTaskToolIfConfigured(
                           getActiveToolSetWithStreaming(streamingContext, requestOptions.threadId),
                           streamingContext,
                         ),
                         requestOptions.threadId,
+                        followUpTelemetry,
                       );
                       const requestScopedFollowUpTools = wrapToolsWithStreamingContext(
                         hookedFollowUpTools,

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -1818,27 +1818,26 @@ export function createAgent(options: AgentOptions): Agent {
     cachedResult: GenerateResult,
     genOptions: GenerateOptions,
     requestedModel: AgentOptions["model"],
-  ): Promise<void> {
+  ): Promise<GenerateResult> {
     if (cachedResult.status !== "complete") {
-      return;
+      return cachedResult;
     }
 
-    const postGenerateHooks = effectiveHooks?.PostGenerate ?? [];
-    if (postGenerateHooks.length === 0) {
-      return;
-    }
-
-    const telemetry =
-      cachedResult.telemetry ??
-      buildExecutionTelemetryFromIds({
-        runId: genOptions._runId ?? createRunId(),
-        threadId: genOptions.threadId,
-        requestedModel,
-      });
+    const telemetry = buildExecutionTelemetryFromIds({
+      runId: genOptions._runId ?? createRunId(),
+      threadId: genOptions.threadId,
+      requestedModel,
+    });
     const result: GenerateResultComplete = {
       ...cachedResult,
       telemetry,
     };
+
+    const postGenerateHooks = effectiveHooks?.PostGenerate ?? [];
+    if (postGenerateHooks.length === 0) {
+      return result;
+    }
+
     const postGenerateInput: PostGenerateInput = {
       hook_event_name: "PostGenerate",
       session_id: genOptions.threadId ?? "default",
@@ -1848,6 +1847,7 @@ export function createAgent(options: AgentOptions): Agent {
       result,
     };
     await invokeHooksWithTimeout(postGenerateHooks, postGenerateInput, null, agent);
+    return result;
   }
 
   /**
@@ -2268,12 +2268,11 @@ export function createAgent(options: AgentOptions): Agent {
 
       // Check for cache short-circuit via respondWith
       if (preGenResult.cachedResult !== undefined) {
-        await invokeCachedPostGenerateHooks(
+        return await invokeCachedPostGenerateHooks(
           preGenResult.cachedResult,
           { ...preGenResult.effectiveOptions, _runId: runId },
           options.model,
         );
-        return preGenResult.cachedResult;
       }
 
       let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
@@ -2780,9 +2779,8 @@ export function createAgent(options: AgentOptions): Agent {
       // Check for cache short-circuit via respondWith
       // For streaming, we convert the cached GenerateResult into StreamParts
       if (preGenResult.cachedResult !== undefined) {
-        const cachedResult = preGenResult.cachedResult;
-        await invokeCachedPostGenerateHooks(
-          cachedResult,
+        const cachedResult = await invokeCachedPostGenerateHooks(
+          preGenResult.cachedResult,
           { ...preGenResult.effectiveOptions, _runId: runId },
           options.model,
         );
@@ -3178,9 +3176,8 @@ export function createAgent(options: AgentOptions): Agent {
       // Check for cache short-circuit via respondWith
       // For streaming response, create a simple text response from the cached result
       if (preGenResult.cachedResult !== undefined) {
-        const cachedResult = preGenResult.cachedResult;
-        await invokeCachedPostGenerateHooks(
-          cachedResult,
+        const cachedResult = await invokeCachedPostGenerateHooks(
+          preGenResult.cachedResult,
           { ...preGenResult.effectiveOptions, _runId: runId },
           options.model,
         );
@@ -3826,9 +3823,8 @@ export function createAgent(options: AgentOptions): Agent {
       // Check for cache short-circuit via respondWith
       // For data stream response, create a simple text response from the cached result
       if (preGenResult.cachedResult !== undefined) {
-        const cachedResult = preGenResult.cachedResult;
-        await invokeCachedPostGenerateHooks(
-          cachedResult,
+        const cachedResult = await invokeCachedPostGenerateHooks(
+          preGenResult.cachedResult,
           { ...preGenResult.effectiveOptions, _runId: runId },
           options.model,
         );

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -1846,8 +1846,16 @@ export function createAgent(options: AgentOptions): Agent {
       options: genOptions,
       result,
     };
-    await invokeHooksWithTimeout(postGenerateHooks, postGenerateInput, null, agent);
-    return result;
+    const hookOutputs = await invokeHooksWithTimeout(
+      postGenerateHooks,
+      postGenerateInput,
+      null,
+      agent,
+    );
+    const updatedResult = extractUpdatedResult<GenerateResultComplete>(hookOutputs);
+    return updatedResult
+      ? { ...updatedResult, telemetry: updatedResult.telemetry ?? telemetry }
+      : result;
   }
 
   /**
@@ -2047,6 +2055,7 @@ export function createAgent(options: AgentOptions): Agent {
             toolCallId: interrupt.toolCallId,
             messages: checkpoint.messages,
             abortSignal: genOptions?.signal,
+            executionTelemetry: resumeTelemetry,
           } as ToolExecutionOptions);
         } catch (error) {
           toolResultOutput = `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`;
@@ -2150,6 +2159,7 @@ export function createAgent(options: AgentOptions): Agent {
         toolCallId: customToolCallId,
         messages: checkpoint.messages,
         abortSignal: genOptions?.signal,
+        executionTelemetry: resumeTelemetry,
         interrupt: async (request: unknown) => {
           // First call: return the stored user response (mirrors the
           // permission-mode wrapper when pendingResponses has a match).
@@ -3437,6 +3447,7 @@ export function createAgent(options: AgentOptions): Agent {
                       });
                     },
                   );
+                  const followUpStartTime = Date.now();
                   followUpBaseOptions = {
                     ...followUpEffectiveOptions,
                     _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
@@ -3491,6 +3502,7 @@ export function createAgent(options: AgentOptions): Agent {
                       requestedModel: followUpModel,
                       responseModelId: followUpResponse?.modelId,
                       usage: followUpUsage,
+                      durationMs: Date.now() - followUpStartTime,
                     });
                     const followUpHookResult: GenerateResultComplete = {
                       status: "complete",
@@ -4143,6 +4155,7 @@ export function createAgent(options: AgentOptions): Agent {
                       });
                     },
                   );
+                  const followUpStartTime = Date.now();
                   followUpBaseOptions = {
                     ...followUpEffectiveOptions,
                     _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
@@ -4197,6 +4210,7 @@ export function createAgent(options: AgentOptions): Agent {
                       requestedModel: followUpModel,
                       responseModelId: followUpResponse?.modelId,
                       usage: followUpUsage,
+                      durationMs: Date.now() - followUpStartTime,
                     });
                     const followUpHookResult: GenerateResultComplete = {
                       status: "complete",

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -124,10 +124,12 @@ class InterruptSignal extends Error {
   }
 }
 
+/** @internal */
 function getCheckpointRunId(checkpoint: Checkpoint | undefined): string | undefined {
   return typeof checkpoint?.metadata?.runId === "string" ? checkpoint.metadata.runId : undefined;
 }
 
+/** @internal */
 function withCheckpointRunId(
   checkpoint: Checkpoint,
   runId: string | undefined,

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -51,6 +51,11 @@ import {
 } from "./hooks.js";
 import { MCPManager } from "./mcp/manager.js";
 import { applyMiddleware, mergeHooks, setupMiddleware } from "./middleware/index.js";
+import {
+  buildExecutionTelemetry,
+  buildExecutionTelemetryFromIds,
+  createRunId,
+} from "./observability/execution-metadata.js";
 import { createDefaultPromptBuilder } from "./prompt-builder/components.js";
 import type {
   PromptContext,
@@ -75,6 +80,7 @@ import type {
   Agent,
   AgentOptions,
   BackendFactory,
+  ExecutionTelemetry,
   GenerateOptions,
   GenerateResult,
   GenerateResultComplete,
@@ -116,6 +122,25 @@ class InterruptSignal extends Error {
     this.name = "InterruptSignal";
     this.interrupt = interrupt;
   }
+}
+
+function getCheckpointRunId(checkpoint: Checkpoint | undefined): string | undefined {
+  return typeof checkpoint?.metadata?.runId === "string" ? checkpoint.metadata.runId : undefined;
+}
+
+function withCheckpointRunId(
+  checkpoint: Checkpoint,
+  runId: string | undefined,
+  updates?: Partial<Omit<Checkpoint, "threadId" | "createdAt">>,
+): Checkpoint {
+  return updateCheckpoint(checkpoint, {
+    ...(updates ?? {}),
+    metadata: {
+      ...(checkpoint.metadata ?? {}),
+      ...(updates?.metadata ?? {}),
+      ...(runId ? { runId } : {}),
+    },
+  });
 }
 
 /**
@@ -540,7 +565,11 @@ function wrapToolsWithPermissionMode(
  *
  * @internal
  */
-function wrapToolsWithTaskManager(tools: ToolSet, taskManager: TaskManager): ToolSet {
+function wrapToolsWithTaskManager(
+  tools: ToolSet,
+  taskManager: TaskManager,
+  telemetry?: ExecutionTelemetry,
+): ToolSet {
   const wrapped: ToolSet = {};
 
   for (const [name, tool] of Object.entries(tools)) {
@@ -558,6 +587,7 @@ function wrapToolsWithTaskManager(tools: ToolSet, taskManager: TaskManager): Too
         const extendedOptions = {
           ...options,
           taskManager,
+          executionTelemetry: telemetry,
         } as ToolExecutionOptions;
         return originalExecute(input, extendedOptions);
       },
@@ -586,6 +616,7 @@ function wrapToolsWithHooks(
   hookRegistration: HookRegistration | undefined,
   agent: Agent,
   sessionId: string,
+  telemetry?: ExecutionTelemetry,
 ): ToolSet {
   // If no tool hooks are registered, return tools unchanged
   if (
@@ -617,6 +648,7 @@ function wrapToolsWithHooks(
           hook_event_name: "PreToolUse",
           session_id: sessionId,
           cwd: process.cwd(),
+          telemetry,
           tool_name: name,
           tool_input: input as Record<string, unknown>,
         };
@@ -652,6 +684,7 @@ function wrapToolsWithHooks(
                 hook_event_name: "PostToolUseFailure",
                 session_id: sessionId,
                 cwd: process.cwd(),
+                telemetry,
                 tool_name: name,
                 tool_input: input as Record<string, unknown>,
                 error,
@@ -687,6 +720,7 @@ function wrapToolsWithHooks(
               hook_event_name: "PostToolUse",
               session_id: sessionId,
               cwd: process.cwd(),
+              telemetry,
               tool_name: name,
               tool_input: input as Record<string, unknown>,
               tool_response: output,
@@ -718,6 +752,7 @@ function wrapToolsWithHooks(
                 hook_event_name: "PostToolUseFailure",
                 session_id: sessionId,
                 cwd: process.cwd(),
+                telemetry,
                 tool_name: name,
                 tool_input: input as Record<string, unknown>,
                 error: error instanceof Error ? error : new Error(String(error)),
@@ -1368,11 +1403,21 @@ export function createAgent(options: AgentOptions): Agent {
    * 1. TaskManager injection - makes taskManager available in execution options
    * 2. Hook wrapping - enables PreToolUse/PostToolUse hooks for observability
    */
-  const applyToolHooks = (tools: ToolSet, threadId?: string): ToolSet => {
+  const applyToolHooks = (
+    tools: ToolSet,
+    threadId?: string,
+    telemetry?: ExecutionTelemetry,
+  ): ToolSet => {
     // First inject TaskManager into execution context
-    const withTaskManager = wrapToolsWithTaskManager(tools, taskManager);
+    const withTaskManager = wrapToolsWithTaskManager(tools, taskManager, telemetry);
     // Then apply hooks for observability
-    return wrapToolsWithHooks(withTaskManager, effectiveHooks, agent, threadId ?? "default");
+    return wrapToolsWithHooks(
+      withTaskManager,
+      effectiveHooks,
+      agent,
+      threadId ?? "default",
+      telemetry,
+    );
   };
 
   /**
@@ -1503,6 +1548,7 @@ export function createAgent(options: AgentOptions): Agent {
     threadId: string,
     messages: ModelMessage[],
     step: number,
+    runId?: string,
   ): Promise<Checkpoint | undefined> {
     if (!options.checkpointer) {
       return undefined;
@@ -1520,6 +1566,10 @@ export function createAgent(options: AgentOptions): Agent {
           todos: [...state.todos],
           files: { ...state.files },
         },
+        metadata: {
+          ...(existingCheckpoint.metadata ?? {}),
+          ...(runId ? { runId } : {}),
+        },
       });
     } else {
       // Create new checkpoint
@@ -1531,6 +1581,7 @@ export function createAgent(options: AgentOptions): Agent {
           todos: [...state.todos],
           files: { ...state.files },
         },
+        metadata: runId ? { runId } : undefined,
       });
     }
 
@@ -1649,6 +1700,11 @@ export function createAgent(options: AgentOptions): Agent {
       // Check if compaction is needed
       const { trigger, reason } = contextManager.shouldCompact(messages);
       if (trigger && reason) {
+        const compactionTelemetry = buildExecutionTelemetryFromIds({
+          runId: genOptions._runId ?? createRunId(),
+          threadId: forkedSessionId ?? genOptions.threadId,
+          requestedModel: options.model,
+        });
         // Calculate token count before compaction
         const tokensBefore = contextManager.tokenCounter.countMessages(messages);
         const messagesBefore = messages.length;
@@ -1660,6 +1716,7 @@ export function createAgent(options: AgentOptions): Agent {
             hook_event_name: "PreCompact",
             session_id: genOptions.threadId ?? "default",
             cwd: process.cwd(),
+            telemetry: compactionTelemetry,
             message_count: messagesBefore,
             tokens_before: tokensBefore,
           };
@@ -1680,6 +1737,7 @@ export function createAgent(options: AgentOptions): Agent {
             hook_event_name: "PostCompact",
             session_id: genOptions.threadId ?? "default",
             cwd: process.cwd(),
+            telemetry: compactionTelemetry,
             messages_before: compactionResult.messagesBefore,
             messages_after: compactionResult.messagesAfter,
             tokens_before: compactionResult.tokensBefore,
@@ -1873,6 +1931,12 @@ export function createAgent(options: AgentOptions): Agent {
       throw new Error(`Cannot resume: no pending interrupt found for thread ${threadId}`);
     }
 
+    const resumeTelemetry = buildExecutionTelemetryFromIds({
+      runId: getCheckpointRunId(checkpoint) ?? createRunId(),
+      threadId,
+      requestedModel: options.model,
+    });
+
     if (interrupt.id !== interruptId) {
       throw new Error(
         `Cannot resume: interrupt ID mismatch. Expected ${interrupt.id}, got ${interruptId}`,
@@ -1894,6 +1958,7 @@ export function createAgent(options: AgentOptions): Agent {
         hook_event_name: "InterruptResolved",
         session_id: threadId,
         cwd: process.cwd(),
+        telemetry: resumeTelemetry,
         interrupt_id: interrupt.id,
         interrupt_type: interrupt.type,
         tool_call_id: interrupt.toolCallId,
@@ -1992,7 +2057,11 @@ export function createAgent(options: AgentOptions): Agent {
       pendingResponses.delete(interrupt.id);
       approvalDecisions.delete(interrupt.toolCallId);
 
-      return { type: "continue", threadId, genOptions };
+      return {
+        type: "continue",
+        threadId,
+        genOptions: { ...genOptions, _runId: resumeTelemetry.runId },
+      };
     }
 
     // For custom interrupts (e.g. ask_user), manually execute the tool so
@@ -2076,7 +2145,7 @@ export function createAgent(options: AgentOptions): Agent {
         return {
           type: "re-interrupted",
           interrupt: newInterrupt,
-          checkpoint: reInterruptCheckpoint,
+          checkpoint: withCheckpointRunId(reInterruptCheckpoint, resumeTelemetry.runId),
         };
       }
       customToolResult = `Tool execution failed: ${executeError instanceof Error ? executeError.message : String(executeError)}`;
@@ -2118,7 +2187,11 @@ export function createAgent(options: AgentOptions): Agent {
     // Clean up
     pendingResponses.delete(interrupt.id);
 
-    return { type: "continue", threadId, genOptions };
+    return {
+      type: "continue",
+      threadId,
+      genOptions: { ...genOptions, _runId: resumeTelemetry.runId },
+    };
   }
 
   const agent: Agent = {
@@ -2133,11 +2206,20 @@ export function createAgent(options: AgentOptions): Agent {
     },
 
     async generate(genOptions: GenerateOptions): Promise<GenerateResult> {
+      let runId = genOptions._runId;
+      if (!runId && genOptions.threadId && !genOptions.forkSession) {
+        const existingCheckpoint = await loadCheckpoint(genOptions.threadId);
+        if (existingCheckpoint?.pendingInterrupt) {
+          runId = getCheckpointRunId(existingCheckpoint);
+        }
+      }
+      runId ??= createRunId();
+
       // Invoke unified PreGenerate hooks
       const preGenerateHooks = effectiveHooks?.PreGenerate ?? [];
       const preGenResult = await invokePreGenerateHooks<GenerateResult>(
         preGenerateHooks,
-        genOptions,
+        { ...genOptions, _runId: runId },
         agent,
       );
 
@@ -2146,7 +2228,7 @@ export function createAgent(options: AgentOptions): Agent {
         return preGenResult.cachedResult;
       }
 
-      let effectiveGenOptions = preGenResult.effectiveOptions;
+      let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
 
       // Initialize retry loop state
       const retryState = createRetryLoopState(
@@ -2160,6 +2242,12 @@ export function createAgent(options: AgentOptions): Agent {
         try {
           const { messages, checkpoint, forkedSessionId } =
             await buildMessages(effectiveGenOptions);
+          const checkpointThreadId = forkedSessionId ?? effectiveGenOptions.threadId;
+          const executionBaseTelemetry = buildExecutionTelemetryFromIds({
+            runId: effectiveGenOptions._runId ?? createRunId(),
+            threadId: checkpointThreadId,
+            requestedModel: retryState.currentModel,
+          });
           // Store for potential emergency compaction in catch block
           lastBuiltMessages = messages;
           const maxSteps = options.maxSteps ?? 10;
@@ -2178,6 +2266,7 @@ export function createAgent(options: AgentOptions): Agent {
           const hookedTools = applyToolHooks(
             addTaskToolIfConfigured(getActiveToolSet(effectiveGenOptions.threadId)),
             effectiveGenOptions.threadId,
+            executionBaseTelemetry,
           );
           const activeTools = wrapToolsWithSignalCatching(hookedTools, signalState);
 
@@ -2205,6 +2294,8 @@ export function createAgent(options: AgentOptions): Agent {
           // the step count reaches maxSteps (whichever comes first).
           const signalStopCondition = () => signalState.interrupt != null;
 
+          const generationStartTime = Date.now();
+
           // Execute generation
           const response = await generateText({
             model: retryState.currentModel,
@@ -2226,13 +2317,21 @@ export function createAgent(options: AgentOptions): Agent {
           // Check for intercepted interrupt signal (cooperative path)
           if (signalState.interrupt) {
             const interrupt = signalState.interrupt.interrupt;
+            const interruptTelemetry = buildExecutionTelemetry({
+              runId: executionBaseTelemetry.runId,
+              threadId: checkpointThreadId,
+              requestedModel: retryState.currentModel,
+              responseModelId: response.response?.modelId,
+              usage: response.usage,
+              providerMetadata: (response as { providerMetadata?: unknown }).providerMetadata,
+              durationMs: Date.now() - generationStartTime,
+            });
 
             // Save checkpoint with messages AND the pending interrupt.
             // The normal completion path saves messages at the end of generate(),
             // but when interrupted we return early. Without saving here, resume()
             // cannot find the checkpoint (or finds one without messages/interrupt).
-            if (effectiveGenOptions.threadId && options.checkpointer) {
-              const checkpointThreadId = forkedSessionId ?? effectiveGenOptions.threadId;
+            if (checkpointThreadId && options.checkpointer) {
               const finalMessages = appendResponseMessages(
                 messages,
                 response.response?.messages,
@@ -2242,11 +2341,16 @@ export function createAgent(options: AgentOptions): Agent {
                 checkpointThreadId,
                 finalMessages,
                 startStep + response.steps.length,
+                interruptTelemetry.runId,
               );
               if (savedCheckpoint) {
-                const withInterrupt = updateCheckpoint(savedCheckpoint, {
-                  pendingInterrupt: interrupt,
-                });
+                const withInterrupt = withCheckpointRunId(
+                  savedCheckpoint,
+                  interruptTelemetry.runId,
+                  {
+                    pendingInterrupt: interrupt,
+                  },
+                );
                 await options.checkpointer.save(withInterrupt);
                 threadCheckpoints.set(checkpointThreadId, withInterrupt);
               }
@@ -2259,6 +2363,7 @@ export function createAgent(options: AgentOptions): Agent {
                 hook_event_name: "InterruptRequested",
                 session_id: effectiveGenOptions.threadId ?? "default",
                 cwd: process.cwd(),
+                telemetry: interruptTelemetry,
                 interrupt_id: interrupt.id,
                 interrupt_type: interrupt.type,
                 tool_call_id: interrupt.toolCallId,
@@ -2271,6 +2376,7 @@ export function createAgent(options: AgentOptions): Agent {
             // Return interrupted result with partial results from the response
             const interruptedResult: GenerateResultInterrupted = {
               status: "interrupted",
+              telemetry: interruptTelemetry,
               interrupt,
               partial: {
                 text: response.text,
@@ -2292,8 +2398,19 @@ export function createAgent(options: AgentOptions): Agent {
             }
           }
 
+          const telemetry = buildExecutionTelemetry({
+            runId: executionBaseTelemetry.runId,
+            threadId: checkpointThreadId,
+            requestedModel: retryState.currentModel,
+            responseModelId: response.response?.modelId,
+            usage: response.usage,
+            providerMetadata: (response as { providerMetadata?: unknown }).providerMetadata,
+            durationMs: Date.now() - generationStartTime,
+          });
+
           const result: GenerateResultComplete = {
             status: "complete",
+            telemetry,
             text: response.text,
             usage: response.usage,
             finishReason: response.finishReason as GenerateResultComplete["finishReason"],
@@ -2312,7 +2429,6 @@ export function createAgent(options: AgentOptions): Agent {
           }
 
           // Save checkpoint - use forked session ID if forking, otherwise use original threadId
-          const checkpointThreadId = forkedSessionId ?? effectiveGenOptions.threadId;
           if (checkpointThreadId && options.checkpointer) {
             const finalMessages = appendResponseMessages(
               messages,
@@ -2323,6 +2439,7 @@ export function createAgent(options: AgentOptions): Agent {
               checkpointThreadId,
               finalMessages,
               startStep + response.steps.length,
+              executionBaseTelemetry.runId,
             );
           }
 
@@ -2334,6 +2451,7 @@ export function createAgent(options: AgentOptions): Agent {
               hook_event_name: "PostGenerate",
               session_id: effectiveGenOptions.threadId ?? "default",
               cwd: process.cwd(),
+              telemetry,
               options: effectiveGenOptions,
               result,
             };
@@ -2413,6 +2531,11 @@ export function createAgent(options: AgentOptions): Agent {
           // Check if this is an InterruptSignal (new interrupt system)
           if (isInterruptSignal(error)) {
             const interrupt = error.interrupt;
+            const interruptTelemetry = buildExecutionTelemetryFromIds({
+              runId: effectiveGenOptions._runId ?? createRunId(),
+              threadId: effectiveGenOptions.threadId,
+              requestedModel: retryState.currentModel,
+            });
 
             // Save checkpoint with messages AND the pending interrupt (catch-block path).
             // lastBuiltMessages holds the messages built before generateText was called.
@@ -2421,11 +2544,16 @@ export function createAgent(options: AgentOptions): Agent {
                 effectiveGenOptions.threadId,
                 lastBuiltMessages ?? [],
                 0,
+                interruptTelemetry.runId,
               );
               if (savedCheckpoint) {
-                const withInterrupt = updateCheckpoint(savedCheckpoint, {
-                  pendingInterrupt: interrupt,
-                });
+                const withInterrupt = withCheckpointRunId(
+                  savedCheckpoint,
+                  interruptTelemetry.runId,
+                  {
+                    pendingInterrupt: interrupt,
+                  },
+                );
                 await options.checkpointer.save(withInterrupt);
                 threadCheckpoints.set(effectiveGenOptions.threadId, withInterrupt);
               }
@@ -2438,6 +2566,7 @@ export function createAgent(options: AgentOptions): Agent {
                 hook_event_name: "InterruptRequested",
                 session_id: effectiveGenOptions.threadId ?? "default",
                 cwd: process.cwd(),
+                telemetry: interruptTelemetry,
                 interrupt_id: interrupt.id,
                 interrupt_type: interrupt.type,
                 tool_call_id: interrupt.toolCallId,
@@ -2450,6 +2579,7 @@ export function createAgent(options: AgentOptions): Agent {
             // Return interrupted result
             const interruptedResult: GenerateResultInterrupted = {
               status: "interrupted",
+              telemetry: interruptTelemetry,
               interrupt,
               partial: {
                 text: "",
@@ -2559,7 +2689,10 @@ export function createAgent(options: AgentOptions): Agent {
 
           if (errorDecision.shouldRetry) {
             if (errorDecision.updatedOptions) {
-              effectiveGenOptions = errorDecision.updatedOptions;
+              effectiveGenOptions = {
+                ...errorDecision.updatedOptions,
+                _runId: errorDecision.updatedOptions._runId ?? effectiveGenOptions._runId,
+              };
             }
             // Update retry state
             Object.assign(retryState, updateRetryLoopState(retryState, errorDecision));
@@ -2579,11 +2712,20 @@ export function createAgent(options: AgentOptions): Agent {
     },
 
     async *stream(genOptions: GenerateOptions): AsyncGenerator<StreamPart> {
+      let runId = genOptions._runId;
+      if (!runId && genOptions.threadId && !genOptions.forkSession) {
+        const existingCheckpoint = await loadCheckpoint(genOptions.threadId);
+        if (existingCheckpoint?.pendingInterrupt) {
+          runId = getCheckpointRunId(existingCheckpoint);
+        }
+      }
+      runId ??= createRunId();
+
       // Invoke unified PreGenerate hooks
       const preGenerateHooks = effectiveHooks?.PreGenerate ?? [];
       const preGenResult = await invokePreGenerateHooks<GenerateResult>(
         preGenerateHooks,
-        genOptions,
+        { ...genOptions, _runId: runId },
         agent,
       );
 
@@ -2627,7 +2769,7 @@ export function createAgent(options: AgentOptions): Agent {
         return;
       }
 
-      let effectiveGenOptions = preGenResult.effectiveOptions;
+      let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
 
       // Initialize retry loop state
       const retryState = createRetryLoopState(
@@ -2642,6 +2784,11 @@ export function createAgent(options: AgentOptions): Agent {
           const maxSteps = options.maxSteps ?? 10;
           const startStep = checkpoint?.step ?? 0;
           const checkpointThreadId = forkedSessionId ?? effectiveGenOptions.threadId;
+          const executionBaseTelemetry = buildExecutionTelemetryFromIds({
+            runId: effectiveGenOptions._runId ?? createRunId(),
+            threadId: checkpointThreadId,
+            requestedModel: retryState.currentModel,
+          });
 
           // Signal state for cooperative signal catching in streaming mode
           const signalState: GenerateSignalState = {};
@@ -2652,6 +2799,7 @@ export function createAgent(options: AgentOptions): Agent {
           const hookedTools = applyToolHooks(
             addTaskToolIfConfigured(getActiveToolSet(effectiveGenOptions.threadId)),
             effectiveGenOptions.threadId,
+            executionBaseTelemetry,
           );
           const activeTools = wrapToolsWithSignalCatching(hookedTools, signalState);
 
@@ -2678,6 +2826,8 @@ export function createAgent(options: AgentOptions): Agent {
           // Stop condition: stop when an interrupt signal was caught, OR when
           // the step count reaches maxSteps.
           const signalStopCondition = () => signalState.interrupt != null;
+          const generationStartTime = Date.now();
+          let firstTextDeltaAt: number | undefined;
 
           // Execute stream
           const response = streamText({
@@ -2699,6 +2849,7 @@ export function createAgent(options: AgentOptions): Agent {
 
           for await (const part of response.fullStream) {
             if (part.type === "text-delta") {
+              firstTextDeltaAt ??= Date.now();
               yield { type: "text-delta", text: part.text };
             } else if (part.type === "reasoning-start") {
               yield {
@@ -2771,8 +2922,20 @@ export function createAgent(options: AgentOptions): Agent {
             }
           }
 
+          const telemetry = buildExecutionTelemetry({
+            runId: executionBaseTelemetry.runId,
+            threadId: checkpointThreadId,
+            requestedModel: retryState.currentModel,
+            responseModelId: responseMeta?.modelId,
+            usage,
+            durationMs: Date.now() - generationStartTime,
+            timeToFirstTokenMs:
+              firstTextDeltaAt !== undefined ? firstTextDeltaAt - generationStartTime : undefined,
+          });
+
           const result: GenerateResultComplete = {
             status: "complete",
+            telemetry,
             text,
             usage,
             finishReason: finishReason as GenerateResultComplete["finishReason"],
@@ -2787,7 +2950,12 @@ export function createAgent(options: AgentOptions): Agent {
               responseMessages.length > 0
                 ? [...messages, ...responseMessages]
                 : buildMessagesFromStepResponses(messages, steps, text);
-            await saveCheckpoint(checkpointThreadId, finalMessages, startStep + steps.length);
+            await saveCheckpoint(
+              checkpointThreadId,
+              finalMessages,
+              startStep + steps.length,
+              telemetry.runId,
+            );
           }
 
           // Save pending interrupt to checkpoint (mirrors generate() pattern)
@@ -2795,7 +2963,7 @@ export function createAgent(options: AgentOptions): Agent {
             const interrupt = signalState.interrupt.interrupt;
             const savedCheckpoint = threadCheckpoints.get(checkpointThreadId);
             if (savedCheckpoint) {
-              const withInterrupt = updateCheckpoint(savedCheckpoint, {
+              const withInterrupt = withCheckpointRunId(savedCheckpoint, telemetry.runId, {
                 pendingInterrupt: interrupt,
               });
               await options.checkpointer.save(withInterrupt);
@@ -2809,6 +2977,7 @@ export function createAgent(options: AgentOptions): Agent {
                 hook_event_name: "InterruptRequested",
                 session_id: effectiveGenOptions.threadId ?? "default",
                 cwd: process.cwd(),
+                telemetry,
                 interrupt_id: interrupt.id,
                 interrupt_type: interrupt.type,
                 tool_call_id: interrupt.toolCallId,
@@ -2826,6 +2995,7 @@ export function createAgent(options: AgentOptions): Agent {
               hook_event_name: "PostGenerate",
               session_id: effectiveGenOptions.threadId ?? "default",
               cwd: process.cwd(),
+              telemetry,
               options: effectiveGenOptions,
               result,
             };
@@ -2912,7 +3082,10 @@ export function createAgent(options: AgentOptions): Agent {
 
           if (errorDecision.shouldRetry) {
             if (errorDecision.updatedOptions) {
-              effectiveGenOptions = errorDecision.updatedOptions;
+              effectiveGenOptions = {
+                ...errorDecision.updatedOptions,
+                _runId: errorDecision.updatedOptions._runId ?? effectiveGenOptions._runId,
+              };
             }
             // Update retry state
             Object.assign(retryState, updateRetryLoopState(retryState, errorDecision));
@@ -2932,11 +3105,20 @@ export function createAgent(options: AgentOptions): Agent {
     },
 
     async streamResponse(genOptions: GenerateOptions): Promise<Response> {
+      let runId = genOptions._runId;
+      if (!runId && genOptions.threadId && !genOptions.forkSession) {
+        const existingCheckpoint = await loadCheckpoint(genOptions.threadId);
+        if (existingCheckpoint?.pendingInterrupt) {
+          runId = getCheckpointRunId(existingCheckpoint);
+        }
+      }
+      runId ??= createRunId();
+
       // Invoke unified PreGenerate hooks
       const preGenerateHooks = effectiveHooks?.PreGenerate ?? [];
       const preGenResult = await invokePreGenerateHooks<GenerateResult>(
         preGenerateHooks,
-        genOptions,
+        { ...genOptions, _runId: runId },
         agent,
       );
 
@@ -2955,7 +3137,7 @@ export function createAgent(options: AgentOptions): Agent {
         });
       }
 
-      let effectiveGenOptions = preGenResult.effectiveOptions;
+      let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
 
       // Initialize retry loop state
       const retryState = createRetryLoopState(
@@ -2968,6 +3150,11 @@ export function createAgent(options: AgentOptions): Agent {
           const { messages, checkpoint } = await buildMessages(effectiveGenOptions);
           const maxSteps = options.maxSteps ?? 10;
           const startStep = checkpoint?.step ?? 0;
+          const executionBaseTelemetry = buildExecutionTelemetryFromIds({
+            runId: effectiveGenOptions._runId ?? createRunId(),
+            threadId: effectiveGenOptions.threadId,
+            requestedModel: retryState.currentModel,
+          });
 
           // Signal state for cooperative signal catching in streaming mode
           const signalState: GenerateSignalState = {};
@@ -2978,6 +3165,7 @@ export function createAgent(options: AgentOptions): Agent {
           const hookedTools = applyToolHooks(
             addTaskToolIfConfigured(getActiveToolSet(effectiveGenOptions.threadId)),
             effectiveGenOptions.threadId,
+            executionBaseTelemetry,
           );
           const activeTools = wrapToolsWithSignalCatching(hookedTools, signalState);
 
@@ -3007,6 +3195,7 @@ export function createAgent(options: AgentOptions): Agent {
           // Stop condition: stop when an interrupt signal was caught, OR when
           // the step count reaches maxSteps.
           const signalStopCondition = () => signalState.interrupt != null;
+          const generationStartTime = Date.now();
 
           // Track step count for incremental checkpointing
           let currentStepCount = 0;
@@ -3051,6 +3240,7 @@ export function createAgent(options: AgentOptions): Agent {
                       effectiveGenOptions.threadId!,
                       streamedMessages,
                       startStep + currentStepCount,
+                      effectiveGenOptions._runId,
                     );
                   }
                 }
@@ -3076,12 +3266,22 @@ export function createAgent(options: AgentOptions): Agent {
                   effectiveGenOptions.threadId!,
                   finalMessages,
                   startStep + finishResult.steps.length,
+                  effectiveGenOptions._runId,
                 );
               }
 
               // Invoke unified PostGenerate hooks
+              const telemetry = buildExecutionTelemetry({
+                runId: executionBaseTelemetry.runId,
+                threadId: effectiveGenOptions.threadId,
+                requestedModel: modelToUse,
+                responseModelId: finishResult.response?.modelId,
+                usage: finishResult.usage,
+                durationMs: Date.now() - generationStartTime,
+              });
               const hookResult: GenerateResultComplete = {
                 status: "complete",
+                telemetry,
                 text: finishResult.text,
                 usage: finishResult.usage,
                 finishReason: finishResult.finishReason as GenerateResultComplete["finishReason"],
@@ -3094,6 +3294,7 @@ export function createAgent(options: AgentOptions): Agent {
                   hook_event_name: "PostGenerate",
                   session_id: effectiveGenOptions.threadId ?? "default",
                   cwd: process.cwd(),
+                  telemetry,
                   options: effectiveGenOptions,
                   result: hookResult,
                 };
@@ -3172,7 +3373,10 @@ export function createAgent(options: AgentOptions): Agent {
                         });
                       },
                     );
-                  followUpBaseOptions = followUpEffectiveOptions;
+                  followUpBaseOptions = {
+                    ...followUpEffectiveOptions,
+                    _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
+                  };
 
                   writer.merge(followUpResult.toUIMessageStream());
                   const followUpText = await followUpResult.text;
@@ -3199,6 +3403,7 @@ export function createAgent(options: AgentOptions): Agent {
                       followUpEffectiveOptions.threadId,
                       currentMessages,
                       startStep + accumulatedStepCount,
+                      followUpEffectiveOptions._runId,
                     );
                   }
 
@@ -3216,8 +3421,16 @@ export function createAgent(options: AgentOptions): Agent {
                   const followUpPostGenerateHooks = effectiveHooks?.PostGenerate ?? [];
                   if (followUpPostGenerateHooks.length > 0) {
                     const followUpFinishReason = await followUpResult.finishReason;
+                    const followUpTelemetry = buildExecutionTelemetry({
+                      runId: followUpEffectiveOptions._runId ?? executionBaseTelemetry.runId,
+                      threadId: followUpEffectiveOptions.threadId,
+                      requestedModel: retryState.currentModel,
+                      responseModelId: followUpResponse?.modelId,
+                      usage: followUpUsage,
+                    });
                     const followUpHookResult: GenerateResultComplete = {
                       status: "complete",
+                      telemetry: followUpTelemetry,
                       text: followUpText,
                       usage: followUpUsage,
                       finishReason: followUpFinishReason as GenerateResultComplete["finishReason"],
@@ -3228,6 +3441,7 @@ export function createAgent(options: AgentOptions): Agent {
                       hook_event_name: "PostGenerate",
                       session_id: followUpEffectiveOptions.threadId ?? "default",
                       cwd: process.cwd(),
+                      telemetry: followUpTelemetry,
                       options: followUpEffectiveOptions,
                       result: followUpHookResult,
                     };
@@ -3271,7 +3485,10 @@ export function createAgent(options: AgentOptions): Agent {
 
           if (errorDecision.shouldRetry) {
             if (errorDecision.updatedOptions) {
-              effectiveGenOptions = errorDecision.updatedOptions;
+              effectiveGenOptions = {
+                ...errorDecision.updatedOptions,
+                _runId: errorDecision.updatedOptions._runId ?? effectiveGenOptions._runId,
+              };
             }
             // Update retry state
             Object.assign(retryState, updateRetryLoopState(retryState, errorDecision));
@@ -3291,6 +3508,15 @@ export function createAgent(options: AgentOptions): Agent {
     },
 
     async streamRaw(genOptions: GenerateOptions) {
+      let runId = genOptions._runId;
+      if (!runId && genOptions.threadId && !genOptions.forkSession) {
+        const existingCheckpoint = await loadCheckpoint(genOptions.threadId);
+        if (existingCheckpoint?.pendingInterrupt) {
+          runId = getCheckpointRunId(existingCheckpoint);
+        }
+      }
+      runId ??= createRunId();
+
       // Invoke unified PreGenerate hooks
       // Note: respondWith cache short-circuit is NOT supported for streamRaw()
       // because it returns the raw AI SDK streamText result which cannot be mocked.
@@ -3298,12 +3524,12 @@ export function createAgent(options: AgentOptions): Agent {
       const preGenerateHooks = effectiveHooks?.PreGenerate ?? [];
       const preGenResult = await invokePreGenerateHooks<GenerateResult>(
         preGenerateHooks,
-        genOptions,
+        { ...genOptions, _runId: runId },
         agent,
       );
 
       // Input transformation is applied even though respondWith is not supported
-      let effectiveGenOptions = preGenResult.effectiveOptions;
+      let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
 
       // Initialize retry loop state
       const retryState = createRetryLoopState(
@@ -3316,6 +3542,11 @@ export function createAgent(options: AgentOptions): Agent {
           const { messages, checkpoint } = await buildMessages(effectiveGenOptions);
           const maxSteps = options.maxSteps ?? 10;
           const startStep = checkpoint?.step ?? 0;
+          const executionBaseTelemetry = buildExecutionTelemetryFromIds({
+            runId: effectiveGenOptions._runId ?? createRunId(),
+            threadId: effectiveGenOptions.threadId,
+            requestedModel: retryState.currentModel,
+          });
 
           // Signal state for cooperative signal catching in streaming mode
           const signalState: GenerateSignalState = {};
@@ -3326,6 +3557,7 @@ export function createAgent(options: AgentOptions): Agent {
           const hookedTools = applyToolHooks(
             addTaskToolIfConfigured(getActiveToolSet(effectiveGenOptions.threadId)),
             effectiveGenOptions.threadId,
+            executionBaseTelemetry,
           );
           const activeTools = wrapToolsWithSignalCatching(hookedTools, signalState);
 
@@ -3356,6 +3588,7 @@ export function createAgent(options: AgentOptions): Agent {
           // Stop condition: stop when an interrupt signal was caught, OR when
           // the step count reaches maxSteps.
           const signalStopCondition = () => signalState.interrupt != null;
+          const generationStartTime = Date.now();
 
           // Execute stream
           const result = streamText({
@@ -3394,6 +3627,7 @@ export function createAgent(options: AgentOptions): Agent {
                       effectiveGenOptions.threadId!,
                       streamedMessages,
                       startStep + currentStepCount,
+                      effectiveGenOptions._runId,
                     );
                   }
                 }
@@ -3419,12 +3653,22 @@ export function createAgent(options: AgentOptions): Agent {
                   effectiveGenOptions.threadId!,
                   finalMessages,
                   startStep + finishResult.steps.length,
+                  effectiveGenOptions._runId,
                 );
               }
 
               // Invoke unified PostGenerate hooks
+              const telemetry = buildExecutionTelemetry({
+                runId: executionBaseTelemetry.runId,
+                threadId: effectiveGenOptions.threadId,
+                requestedModel: retryState.currentModel,
+                responseModelId: finishResult.response?.modelId,
+                usage: finishResult.usage,
+                durationMs: Date.now() - generationStartTime,
+              });
               const hookResult: GenerateResultComplete = {
                 status: "complete",
+                telemetry,
                 text: finishResult.text,
                 usage: finishResult.usage,
                 finishReason: finishResult.finishReason as GenerateResultComplete["finishReason"],
@@ -3437,6 +3681,7 @@ export function createAgent(options: AgentOptions): Agent {
                   hook_event_name: "PostGenerate",
                   session_id: effectiveGenOptions.threadId ?? "default",
                   cwd: process.cwd(),
+                  telemetry,
                   options: effectiveGenOptions,
                   result: hookResult,
                 };
@@ -3471,7 +3716,10 @@ export function createAgent(options: AgentOptions): Agent {
 
           if (errorDecision.shouldRetry) {
             if (errorDecision.updatedOptions) {
-              effectiveGenOptions = errorDecision.updatedOptions;
+              effectiveGenOptions = {
+                ...errorDecision.updatedOptions,
+                _runId: errorDecision.updatedOptions._runId ?? effectiveGenOptions._runId,
+              };
             }
             // Update retry state
             Object.assign(retryState, updateRetryLoopState(retryState, errorDecision));
@@ -3491,11 +3739,20 @@ export function createAgent(options: AgentOptions): Agent {
     },
 
     async streamDataResponse(genOptions: GenerateOptions): Promise<Response> {
+      let runId = genOptions._runId;
+      if (!runId && genOptions.threadId && !genOptions.forkSession) {
+        const existingCheckpoint = await loadCheckpoint(genOptions.threadId);
+        if (existingCheckpoint?.pendingInterrupt) {
+          runId = getCheckpointRunId(existingCheckpoint);
+        }
+      }
+      runId ??= createRunId();
+
       // Invoke unified PreGenerate hooks
       const preGenerateHooks = effectiveHooks?.PreGenerate ?? [];
       const preGenResult = await invokePreGenerateHooks<GenerateResult>(
         preGenerateHooks,
-        genOptions,
+        { ...genOptions, _runId: runId },
         agent,
       );
 
@@ -3514,7 +3771,7 @@ export function createAgent(options: AgentOptions): Agent {
         });
       }
 
-      let effectiveGenOptions = preGenResult.effectiveOptions;
+      let effectiveGenOptions = { ...preGenResult.effectiveOptions, _runId: runId };
 
       // Initialize retry loop state
       const retryState = createRetryLoopState(
@@ -3527,6 +3784,11 @@ export function createAgent(options: AgentOptions): Agent {
           const { messages, checkpoint } = await buildMessages(effectiveGenOptions);
           const maxSteps = options.maxSteps ?? 10;
           const startStep = checkpoint?.step ?? 0;
+          const executionBaseTelemetry = buildExecutionTelemetryFromIds({
+            runId: effectiveGenOptions._runId ?? createRunId(),
+            threadId: effectiveGenOptions.threadId,
+            requestedModel: retryState.currentModel,
+          });
 
           // Capture currentModel for use in the callback closure
           const modelToUse = retryState.currentModel;
@@ -3554,6 +3816,7 @@ export function createAgent(options: AgentOptions): Agent {
                   streamingContext, // Pass streaming context for streaming subagents
                 ),
                 effectiveGenOptions.threadId,
+                executionBaseTelemetry,
               );
               const requestScopedStreamingTools = wrapToolsWithStreamingContext(
                 hookedStreamingTools,
@@ -3592,6 +3855,7 @@ export function createAgent(options: AgentOptions): Agent {
               // Stop condition: stop when a flow-control signal was caught, OR when
               // the step count reaches maxSteps.
               const signalStopCondition = () => signalState.interrupt != null;
+              const generationStartTime = Date.now();
 
               // Execute stream
               const result = streamText({
@@ -3630,6 +3894,7 @@ export function createAgent(options: AgentOptions): Agent {
                           effectiveGenOptions.threadId!,
                           streamedMessages,
                           startStep + currentStepCount,
+                          effectiveGenOptions._runId,
                         );
                       }
                     }
@@ -3655,12 +3920,22 @@ export function createAgent(options: AgentOptions): Agent {
                       effectiveGenOptions.threadId!,
                       finalMessages,
                       startStep + finishResult.steps.length,
+                      effectiveGenOptions._runId,
                     );
                   }
 
                   // Invoke unified PostGenerate hooks
+                  const telemetry = buildExecutionTelemetry({
+                    runId: executionBaseTelemetry.runId,
+                    threadId: effectiveGenOptions.threadId,
+                    requestedModel: modelToUse,
+                    responseModelId: finishResult.response?.modelId,
+                    usage: finishResult.usage,
+                    durationMs: Date.now() - generationStartTime,
+                  });
                   const hookResult: GenerateResultComplete = {
                     status: "complete",
+                    telemetry,
                     text: finishResult.text,
                     usage: finishResult.usage,
                     finishReason:
@@ -3674,6 +3949,7 @@ export function createAgent(options: AgentOptions): Agent {
                       hook_event_name: "PostGenerate",
                       session_id: effectiveGenOptions.threadId ?? "default",
                       cwd: process.cwd(),
+                      telemetry,
                       options: effectiveGenOptions,
                       result: hookResult,
                     };
@@ -3695,9 +3971,13 @@ export function createAgent(options: AgentOptions): Agent {
                 const interrupt = signalState.interrupt.interrupt;
                 const savedCheckpoint = threadCheckpoints.get(effectiveGenOptions.threadId);
                 if (savedCheckpoint) {
-                  const withInterrupt = updateCheckpoint(savedCheckpoint, {
-                    pendingInterrupt: interrupt,
-                  });
+                  const withInterrupt = withCheckpointRunId(
+                    savedCheckpoint,
+                    executionBaseTelemetry.runId,
+                    {
+                      pendingInterrupt: interrupt,
+                    },
+                  );
                   await options.checkpointer.save(withInterrupt);
                   threadCheckpoints.set(effectiveGenOptions.threadId, withInterrupt);
                 }
@@ -3709,6 +3989,7 @@ export function createAgent(options: AgentOptions): Agent {
                     hook_event_name: "InterruptRequested",
                     session_id: effectiveGenOptions.threadId ?? "default",
                     cwd: process.cwd(),
+                    telemetry: executionBaseTelemetry,
                     interrupt_id: interrupt.id,
                     interrupt_type: interrupt.type,
                     tool_call_id: interrupt.toolCallId,
@@ -3788,7 +4069,10 @@ export function createAgent(options: AgentOptions): Agent {
                         });
                       },
                     );
-                  followUpBaseOptions = followUpEffectiveOptions;
+                  followUpBaseOptions = {
+                    ...followUpEffectiveOptions,
+                    _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
+                  };
 
                   writer.merge(followUpResult.toUIMessageStream());
                   const followUpText = await followUpResult.text;
@@ -3815,6 +4099,7 @@ export function createAgent(options: AgentOptions): Agent {
                       followUpEffectiveOptions.threadId,
                       currentMessages,
                       startStep + accumulatedStepCount,
+                      followUpEffectiveOptions._runId,
                     );
                   }
 
@@ -3832,8 +4117,16 @@ export function createAgent(options: AgentOptions): Agent {
                   const followUpPostGenerateHooks = effectiveHooks?.PostGenerate ?? [];
                   if (followUpPostGenerateHooks.length > 0) {
                     const followUpFinishReason = await followUpResult.finishReason;
+                    const followUpTelemetry = buildExecutionTelemetry({
+                      runId: followUpEffectiveOptions._runId ?? executionBaseTelemetry.runId,
+                      threadId: followUpEffectiveOptions.threadId,
+                      requestedModel: retryState.currentModel,
+                      responseModelId: followUpResponse?.modelId,
+                      usage: followUpUsage,
+                    });
                     const followUpHookResult: GenerateResultComplete = {
                       status: "complete",
+                      telemetry: followUpTelemetry,
                       text: followUpText,
                       usage: followUpUsage,
                       finishReason: followUpFinishReason as GenerateResultComplete["finishReason"],
@@ -3844,6 +4137,7 @@ export function createAgent(options: AgentOptions): Agent {
                       hook_event_name: "PostGenerate",
                       session_id: followUpEffectiveOptions.threadId ?? "default",
                       cwd: process.cwd(),
+                      telemetry: followUpTelemetry,
                       options: followUpEffectiveOptions,
                       result: followUpHookResult,
                     };
@@ -3887,7 +4181,10 @@ export function createAgent(options: AgentOptions): Agent {
 
           if (errorDecision.shouldRetry) {
             if (errorDecision.updatedOptions) {
-              effectiveGenOptions = errorDecision.updatedOptions;
+              effectiveGenOptions = {
+                ...errorDecision.updatedOptions,
+                _runId: errorDecision.updatedOptions._runId ?? effectiveGenOptions._runId,
+              };
             }
             // Update retry state
             Object.assign(retryState, updateRetryLoopState(retryState, errorDecision));
@@ -3944,6 +4241,11 @@ export function createAgent(options: AgentOptions): Agent {
       if (outcome.type === "re-interrupted") {
         return {
           status: "interrupted",
+          telemetry: buildExecutionTelemetryFromIds({
+            runId: getCheckpointRunId(outcome.checkpoint) ?? createRunId(),
+            threadId,
+            requestedModel: options.model,
+          }),
           interrupt: outcome.interrupt,
           partial: undefined,
         } as GenerateResultInterrupted;

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -1812,6 +1812,42 @@ export function createAgent(options: AgentOptions): Agent {
     return null;
   }
 
+  async function invokeCachedPostGenerateHooks(
+    cachedResult: GenerateResult,
+    genOptions: GenerateOptions,
+    requestedModel: AgentOptions["model"],
+  ): Promise<void> {
+    if (cachedResult.status !== "complete") {
+      return;
+    }
+
+    const postGenerateHooks = effectiveHooks?.PostGenerate ?? [];
+    if (postGenerateHooks.length === 0) {
+      return;
+    }
+
+    const telemetry =
+      cachedResult.telemetry ??
+      buildExecutionTelemetryFromIds({
+        runId: genOptions._runId ?? createRunId(),
+        threadId: genOptions.threadId,
+        requestedModel,
+      });
+    const result: GenerateResultComplete = {
+      ...cachedResult,
+      telemetry,
+    };
+    const postGenerateInput: PostGenerateInput = {
+      hook_event_name: "PostGenerate",
+      session_id: genOptions.threadId ?? "default",
+      cwd: process.cwd(),
+      telemetry,
+      options: genOptions,
+      result,
+    };
+    await invokeHooksWithTimeout(postGenerateHooks, postGenerateInput, null, agent);
+  }
+
   /**
    * Starts a `streamText()` request with the same retry pipeline used by the
    * top-level streaming entrypoints.
@@ -1828,6 +1864,7 @@ export function createAgent(options: AgentOptions): Agent {
   ): Promise<{
     result: ReturnType<typeof streamText>;
     effectiveOptions: GenerateOptions;
+    currentModel: AgentOptions["model"];
   }> {
     let requestOptions = initialGenOptions;
     const retryState = createRetryLoopState(
@@ -1840,6 +1877,7 @@ export function createAgent(options: AgentOptions): Agent {
         return {
           result: createRequest(requestOptions, retryState.currentModel),
           effectiveOptions: requestOptions,
+          currentModel: retryState.currentModel,
         };
       } catch (error) {
         const normalizedError = normalizeError(
@@ -2137,15 +2175,18 @@ export function createAgent(options: AgentOptions): Agent {
       if (isInterruptSignal(executeError)) {
         // Tool threw another interrupt — persist it and return re-interrupted
         const newInterrupt = executeError.interrupt;
-        const reInterruptCheckpoint = updateCheckpoint(checkpoint, {
-          pendingInterrupt: newInterrupt,
-        });
+        const reInterruptCheckpoint = withCheckpointRunId(
+          updateCheckpoint(checkpoint, {
+            pendingInterrupt: newInterrupt,
+          }),
+          resumeTelemetry.runId,
+        );
         await options.checkpointer.save(reInterruptCheckpoint);
         threadCheckpoints.set(threadId, reInterruptCheckpoint);
         return {
           type: "re-interrupted",
           interrupt: newInterrupt,
-          checkpoint: withCheckpointRunId(reInterruptCheckpoint, resumeTelemetry.runId),
+          checkpoint: reInterruptCheckpoint,
         };
       }
       customToolResult = `Tool execution failed: ${executeError instanceof Error ? executeError.message : String(executeError)}`;
@@ -2225,6 +2266,11 @@ export function createAgent(options: AgentOptions): Agent {
 
       // Check for cache short-circuit via respondWith
       if (preGenResult.cachedResult !== undefined) {
+        await invokeCachedPostGenerateHooks(
+          preGenResult.cachedResult,
+          { ...preGenResult.effectiveOptions, _runId: runId },
+          options.model,
+        );
         return preGenResult.cachedResult;
       }
 
@@ -2733,6 +2779,11 @@ export function createAgent(options: AgentOptions): Agent {
       // For streaming, we convert the cached GenerateResult into StreamParts
       if (preGenResult.cachedResult !== undefined) {
         const cachedResult = preGenResult.cachedResult;
+        await invokeCachedPostGenerateHooks(
+          cachedResult,
+          { ...preGenResult.effectiveOptions, _runId: runId },
+          options.model,
+        );
         // Only process complete results (interrupted results can't be cached)
         if (cachedResult.status === "complete") {
           // Yield cached result as stream parts
@@ -3126,6 +3177,11 @@ export function createAgent(options: AgentOptions): Agent {
       // For streaming response, create a simple text response from the cached result
       if (preGenResult.cachedResult !== undefined) {
         const cachedResult = preGenResult.cachedResult;
+        await invokeCachedPostGenerateHooks(
+          cachedResult,
+          { ...preGenResult.effectiveOptions, _runId: runId },
+          options.model,
+        );
         // For cached results, return a simple Response with the cached text
         // This is compatible with useChat and provides immediate delivery
         // Only complete results can be cached
@@ -3337,42 +3393,45 @@ export function createAgent(options: AgentOptions): Agent {
                       { role: "user" as const, content: followUpPrompt },
                     ],
                   };
-                  const { result: followUpResult, effectiveOptions: followUpEffectiveOptions } =
-                    await startRetriedStreamText(
-                      followUpRequestOptions,
-                      (requestOptions, currentModel) => {
-                        const followUpMessages = requestOptions.messages ?? [];
-                        const followUpTools = applyToolHooks(
-                          addTaskToolIfConfigured(getActiveToolSet(requestOptions.threadId)),
-                          requestOptions.threadId,
-                        );
-                        const activeFollowUpTools = wrapToolsWithSignalCatching(
-                          followUpTools,
-                          signalState,
-                        );
-                        const followUpPromptContext = buildPromptContext(
-                          requestOptions,
-                          followUpMessages,
-                          requestOptions.threadId,
-                        );
+                  const {
+                    result: followUpResult,
+                    effectiveOptions: followUpEffectiveOptions,
+                    currentModel: followUpModel,
+                  } = await startRetriedStreamText(
+                    followUpRequestOptions,
+                    (requestOptions, currentModel) => {
+                      const followUpMessages = requestOptions.messages ?? [];
+                      const followUpTools = applyToolHooks(
+                        addTaskToolIfConfigured(getActiveToolSet(requestOptions.threadId)),
+                        requestOptions.threadId,
+                      );
+                      const activeFollowUpTools = wrapToolsWithSignalCatching(
+                        followUpTools,
+                        signalState,
+                      );
+                      const followUpPromptContext = buildPromptContext(
+                        requestOptions,
+                        followUpMessages,
+                        requestOptions.threadId,
+                      );
 
-                        return streamText({
-                          model: currentModel,
-                          system: getSystemPrompt(followUpPromptContext),
-                          messages: followUpMessages,
-                          tools: activeFollowUpTools as ToolSet,
-                          maxOutputTokens: requestOptions.maxTokens,
-                          temperature: requestOptions.temperature,
-                          stopSequences: requestOptions.stopSequences,
-                          abortSignal: requestOptions.signal,
-                          stopWhen: [signalStopCondition, stepCountIs(maxSteps)],
-                          output: requestOptions.output,
-                          // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
-                          providerOptions: requestOptions.providerOptions as any,
-                          headers: requestOptions.headers,
-                        });
-                      },
-                    );
+                      return streamText({
+                        model: currentModel,
+                        system: getSystemPrompt(followUpPromptContext),
+                        messages: followUpMessages,
+                        tools: activeFollowUpTools as ToolSet,
+                        maxOutputTokens: requestOptions.maxTokens,
+                        temperature: requestOptions.temperature,
+                        stopSequences: requestOptions.stopSequences,
+                        abortSignal: requestOptions.signal,
+                        stopWhen: [signalStopCondition, stepCountIs(maxSteps)],
+                        output: requestOptions.output,
+                        // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
+                        providerOptions: requestOptions.providerOptions as any,
+                        headers: requestOptions.headers,
+                      });
+                    },
+                  );
                   followUpBaseOptions = {
                     ...followUpEffectiveOptions,
                     _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
@@ -3424,7 +3483,7 @@ export function createAgent(options: AgentOptions): Agent {
                     const followUpTelemetry = buildExecutionTelemetry({
                       runId: followUpEffectiveOptions._runId ?? executionBaseTelemetry.runId,
                       threadId: followUpEffectiveOptions.threadId,
-                      requestedModel: retryState.currentModel,
+                      requestedModel: followUpModel,
                       responseModelId: followUpResponse?.modelId,
                       usage: followUpUsage,
                     });
@@ -3760,6 +3819,11 @@ export function createAgent(options: AgentOptions): Agent {
       // For data stream response, create a simple text response from the cached result
       if (preGenResult.cachedResult !== undefined) {
         const cachedResult = preGenResult.cachedResult;
+        await invokeCachedPostGenerateHooks(
+          cachedResult,
+          { ...preGenResult.effectiveOptions, _runId: runId },
+          options.model,
+        );
         // For cached results, return a simple Response with the cached text
         // This is compatible with useChat and provides immediate delivery
         // Only complete results can be cached
@@ -4023,52 +4087,52 @@ export function createAgent(options: AgentOptions): Agent {
                       { role: "user" as const, content: followUpPrompt },
                     ],
                   };
-                  const { result: followUpResult, effectiveOptions: followUpEffectiveOptions } =
-                    await startRetriedStreamText(
-                      followUpRequestOptions,
-                      (requestOptions, currentModel) => {
-                        const followUpMessages = requestOptions.messages ?? [];
-                        const hookedFollowUpTools = applyToolHooks(
-                          addTaskToolIfConfigured(
-                            getActiveToolSetWithStreaming(
-                              streamingContext,
-                              requestOptions.threadId,
-                            ),
-                            streamingContext,
-                          ),
-                          requestOptions.threadId,
-                        );
-                        const requestScopedFollowUpTools = wrapToolsWithStreamingContext(
-                          hookedFollowUpTools,
+                  const {
+                    result: followUpResult,
+                    effectiveOptions: followUpEffectiveOptions,
+                    currentModel: followUpModel,
+                  } = await startRetriedStreamText(
+                    followUpRequestOptions,
+                    (requestOptions, currentModel) => {
+                      const followUpMessages = requestOptions.messages ?? [];
+                      const hookedFollowUpTools = applyToolHooks(
+                        addTaskToolIfConfigured(
+                          getActiveToolSetWithStreaming(streamingContext, requestOptions.threadId),
                           streamingContext,
-                        );
-                        const activeFollowUpTools = wrapToolsWithSignalCatching(
-                          requestScopedFollowUpTools,
-                          signalState,
-                        );
-                        const followUpPromptContext = buildPromptContext(
-                          requestOptions,
-                          followUpMessages,
-                          requestOptions.threadId,
-                        );
+                        ),
+                        requestOptions.threadId,
+                      );
+                      const requestScopedFollowUpTools = wrapToolsWithStreamingContext(
+                        hookedFollowUpTools,
+                        streamingContext,
+                      );
+                      const activeFollowUpTools = wrapToolsWithSignalCatching(
+                        requestScopedFollowUpTools,
+                        signalState,
+                      );
+                      const followUpPromptContext = buildPromptContext(
+                        requestOptions,
+                        followUpMessages,
+                        requestOptions.threadId,
+                      );
 
-                        return streamText({
-                          model: currentModel,
-                          system: getSystemPrompt(followUpPromptContext),
-                          messages: followUpMessages,
-                          tools: activeFollowUpTools as ToolSet,
-                          maxOutputTokens: requestOptions.maxTokens,
-                          temperature: requestOptions.temperature,
-                          stopSequences: requestOptions.stopSequences,
-                          abortSignal: requestOptions.signal,
-                          stopWhen: [signalStopCondition, stepCountIs(maxSteps)],
-                          output: requestOptions.output,
-                          // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
-                          providerOptions: requestOptions.providerOptions as any,
-                          headers: requestOptions.headers,
-                        });
-                      },
-                    );
+                      return streamText({
+                        model: currentModel,
+                        system: getSystemPrompt(followUpPromptContext),
+                        messages: followUpMessages,
+                        tools: activeFollowUpTools as ToolSet,
+                        maxOutputTokens: requestOptions.maxTokens,
+                        temperature: requestOptions.temperature,
+                        stopSequences: requestOptions.stopSequences,
+                        abortSignal: requestOptions.signal,
+                        stopWhen: [signalStopCondition, stepCountIs(maxSteps)],
+                        output: requestOptions.output,
+                        // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
+                        providerOptions: requestOptions.providerOptions as any,
+                        headers: requestOptions.headers,
+                      });
+                    },
+                  );
                   followUpBaseOptions = {
                     ...followUpEffectiveOptions,
                     _runId: followUpEffectiveOptions._runId ?? followUpBaseOptions._runId,
@@ -4120,7 +4184,7 @@ export function createAgent(options: AgentOptions): Agent {
                     const followUpTelemetry = buildExecutionTelemetry({
                       runId: followUpEffectiveOptions._runId ?? executionBaseTelemetry.runId,
                       threadId: followUpEffectiveOptions.threadId,
-                      requestedModel: retryState.currentModel,
+                      requestedModel: followUpModel,
                       responseModelId: followUpResponse?.modelId,
                       usage: followUpUsage,
                     });

--- a/packages/agent-sdk/src/generation-helpers.ts
+++ b/packages/agent-sdk/src/generation-helpers.ts
@@ -17,6 +17,7 @@ import {
   extractUpdatedInput,
   invokeHooksWithTimeout,
 } from "./hooks.js";
+import { buildExecutionTelemetryFromIds } from "./observability/execution-metadata.js";
 import type {
   Agent,
   GenerateOptions,
@@ -170,6 +171,11 @@ export async function invokePreGenerateHooks<T = GenerateResult>(
     hook_event_name: "PreGenerate",
     session_id: genOptions.threadId ?? "default",
     cwd: process.cwd(),
+    telemetry: buildExecutionTelemetryFromIds({
+      runId: genOptions._runId ?? "run_unknown",
+      threadId: genOptions.threadId,
+      requestedModel: agent.options.model,
+    }),
     options: genOptions,
   };
 
@@ -535,6 +541,11 @@ async function emitRetryDecisionHooks(
     hook_event_name: "GenerationRetryDecision",
     session_id: genOptions.threadId ?? "default",
     cwd: process.cwd(),
+    telemetry: buildExecutionTelemetryFromIds({
+      runId: genOptions._runId ?? "run_unknown",
+      threadId: genOptions.threadId,
+      requestedModel: state.currentModel,
+    }),
     options: genOptions,
     error,
     requestClass: decision.requestClass,
@@ -585,6 +596,11 @@ export async function handleGenerationError({
       hook_event_name: "PostGenerateFailure",
       session_id: genOptions.threadId ?? "default",
       cwd: process.cwd(),
+      telemetry: buildExecutionTelemetryFromIds({
+        runId: genOptions._runId ?? "run_unknown",
+        threadId: genOptions.threadId,
+        requestedModel: state.currentModel,
+      }),
       options: genOptions,
       error,
       requestClass,

--- a/packages/agent-sdk/src/hooks/audit.ts
+++ b/packages/agent-sdk/src/hooks/audit.ts
@@ -255,7 +255,12 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       toolUseId,
       toolName: preToolInput.tool_name,
       toolInput: preToolInput.tool_input,
-      metadata,
+      metadata: {
+        ...metadata,
+        threadId: preToolInput.telemetry?.threadId,
+        runId: preToolInput.telemetry?.runId,
+        model: preToolInput.telemetry?.modelId ?? preToolInput.telemetry?.requestedModelId,
+      },
     };
 
     await onEvent(event);
@@ -282,7 +287,12 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       toolName: postToolInput.tool_name,
       toolInput: postToolInput.tool_input,
       toolOutput: postToolInput.tool_response,
-      metadata,
+      metadata: {
+        ...metadata,
+        threadId: postToolInput.telemetry?.threadId,
+        runId: postToolInput.telemetry?.runId,
+        model: postToolInput.telemetry?.modelId ?? postToolInput.telemetry?.requestedModelId,
+      },
     };
 
     await onEvent(event);
@@ -310,7 +320,12 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       toolInput: failureInput.tool_input,
       error:
         typeof failureInput.error === "string" ? failureInput.error : failureInput.error.message,
-      metadata,
+      metadata: {
+        ...metadata,
+        threadId: failureInput.telemetry?.threadId,
+        runId: failureInput.telemetry?.runId,
+        model: failureInput.telemetry?.modelId ?? failureInput.telemetry?.requestedModelId,
+      },
     };
 
     await onEvent(event);
@@ -332,8 +347,11 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       event: "PreGenerate",
       timestamp: Date.now(),
       sessionId: preGenInput.session_id,
+      model: preGenInput.telemetry?.requestedModelId,
       metadata: {
         ...metadata,
+        threadId: preGenInput.telemetry?.threadId,
+        runId: preGenInput.telemetry?.runId,
         messageCount: preGenInput.options.messages?.length || 0,
       },
     };
@@ -357,9 +375,12 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       event: "PostGenerate",
       timestamp: Date.now(),
       sessionId: postGenInput.session_id,
+      model: postGenInput.result.telemetry?.modelId ?? postGenInput.telemetry?.requestedModelId,
       usage: postGenInput.result.usage,
       metadata: {
         ...metadata,
+        threadId: postGenInput.result.telemetry?.threadId,
+        runId: postGenInput.result.telemetry?.runId,
         finishReason: postGenInput.result.finishReason,
       },
     };
@@ -384,7 +405,12 @@ export function createAuditHooks(options: AuditHooksOptions): HookCallback[] {
       timestamp: Date.now(),
       sessionId: failureInput.session_id,
       error: failureInput.error.message,
-      metadata,
+      model: failureInput.telemetry?.requestedModelId,
+      metadata: {
+        ...metadata,
+        threadId: failureInput.telemetry?.threadId,
+        runId: failureInput.telemetry?.runId,
+      },
     };
 
     await onEvent(event);

--- a/packages/agent-sdk/src/hooks/cache.ts
+++ b/packages/agent-sdk/src/hooks/cache.ts
@@ -7,6 +7,7 @@
  * @packageDocumentation
  */
 
+import { resolveModelIdentity } from "../observability/execution-metadata.js";
 import type {
   HookCallback,
   HookCallbackContext,
@@ -132,20 +133,7 @@ export interface CacheHooksOptions {
  */
 function defaultKeyGenerator(input: PreGenerateInput, context?: HookCallbackContext): string {
   const opts = input.options;
-  // Extract model identifier from agent context
-  // The AI SDK LanguageModel may have modelId as a property or be a string
-  const model = context?.agent?.options?.model;
-  let modelId = "unknown";
-  if (model) {
-    if (typeof model === "string") {
-      modelId = model;
-    } else if ("modelId" in model && typeof (model as { modelId?: string }).modelId === "string") {
-      modelId = (model as { modelId: string }).modelId;
-    } else if ("specificationVersion" in model) {
-      // For LanguageModel objects, try to extract identifier from provider
-      modelId = String(model);
-    }
-  }
+  const modelId = resolveModelIdentity(context?.agent?.options?.model).modelId ?? "unknown";
   const keyData = {
     // Include model to differentiate between different models
     model: modelId,

--- a/packages/agent-sdk/src/hooks/logging.ts
+++ b/packages/agent-sdk/src/hooks/logging.ts
@@ -166,6 +166,11 @@ export function createLoggingHooks(options: LoggingHooksOptions = {}): HookCallb
     const messageInfo = logFullMessages ? JSON.stringify(messages) : formatMessageCount(messages);
 
     let logMsg = `${prefix} PreGenerate:`;
+    if (preGenInput.telemetry?.runId) logMsg += `\n  Run: ${preGenInput.telemetry.runId}`;
+    if (preGenInput.telemetry?.threadId) logMsg += `\n  Thread: ${preGenInput.telemetry.threadId}`;
+    if (preGenInput.telemetry?.requestedModelId) {
+      logMsg += `\n  Model: ${preGenInput.telemetry.requestedModelId}`;
+    }
     logMsg += `\n  Messages: ${messageInfo}`;
     if (temperature !== undefined) logMsg += `\n  Temperature: ${temperature}`;
     if (maxTokens !== undefined) logMsg += `\n  MaxTokens: ${maxTokens}`;
@@ -189,6 +194,14 @@ export function createLoggingHooks(options: LoggingHooksOptions = {}): HookCallb
     const { result } = postGenInput;
 
     let logMsg = `${prefix} PostGenerate:`;
+    if (postGenInput.result.telemetry?.runId)
+      logMsg += `\n  Run: ${postGenInput.result.telemetry.runId}`;
+    if (postGenInput.result.telemetry?.threadId) {
+      logMsg += `\n  Thread: ${postGenInput.result.telemetry.threadId}`;
+    }
+    if (postGenInput.result.telemetry?.modelId) {
+      logMsg += `\n  Model: ${postGenInput.result.telemetry.modelId}`;
+    }
     logMsg += `\n  Text: ${truncate(result.text || "", maxTextLength)}`;
     logMsg += `\n  Finish: ${result.finishReason}`;
 
@@ -218,6 +231,12 @@ export function createLoggingHooks(options: LoggingHooksOptions = {}): HookCallb
     const failureInput = input as PostGenerateFailureInput;
 
     let logMsg = `${prefix} PostGenerateFailure:`;
+    if (failureInput.telemetry?.runId) logMsg += `\n  Run: ${failureInput.telemetry.runId}`;
+    if (failureInput.telemetry?.threadId)
+      logMsg += `\n  Thread: ${failureInput.telemetry.threadId}`;
+    if (failureInput.telemetry?.requestedModelId) {
+      logMsg += `\n  Model: ${failureInput.telemetry.requestedModelId}`;
+    }
     logMsg += `\n  Error: ${failureInput.error.message}`;
 
     // Add timing if available

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -492,6 +492,7 @@ export {
   createObservabilityPreset,
   createOTLPSpanExporter,
   createPrettyFormatter,
+  createTracingHooks,
   // Tracing
   createTracer,
   // Metrics

--- a/packages/agent-sdk/src/middleware/logging.ts
+++ b/packages/agent-sdk/src/middleware/logging.ts
@@ -227,6 +227,8 @@ export function createLoggingMiddleware(options: LoggingMiddlewareOptions): Agen
             messageCount: preInput.options.messages?.length ?? 0,
             hasPrompt: !!preInput.options.prompt,
             threadId: preInput.options.threadId,
+            runId: preInput.telemetry?.runId,
+            model: preInput.telemetry?.requestedModelId,
           });
 
           return {};
@@ -240,6 +242,9 @@ export function createLoggingMiddleware(options: LoggingMiddlewareOptions): Agen
             finishReason: postInput.result.finishReason,
             text: truncate(postInput.result.text ?? "", maxContentLength),
             stepCount: postInput.result.steps?.length ?? 0,
+            runId: postInput.result.telemetry?.runId,
+            threadId: postInput.result.telemetry?.threadId,
+            model: postInput.result.telemetry?.modelId,
           };
 
           if (postInput.result.usage) {
@@ -272,6 +277,9 @@ export function createLoggingMiddleware(options: LoggingMiddlewareOptions): Agen
 
           const context: Record<string, unknown> = {
             error: failInput.error?.message ?? "Unknown error",
+            runId: failInput.telemetry?.runId,
+            threadId: failInput.telemetry?.threadId,
+            model: failInput.telemetry?.requestedModelId,
           };
 
           if (includeTiming) {

--- a/packages/agent-sdk/src/observability/events.ts
+++ b/packages/agent-sdk/src/observability/events.ts
@@ -77,6 +77,11 @@ export interface EventExporterOptions {
  */
 export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
   const timestamp = new Date().toISOString();
+  const executionMetadata = {
+    ...(event.telemetry?.threadId ? { thread_id: event.telemetry.threadId } : {}),
+    ...(event.telemetry?.runId ? { run_id: event.telemetry.runId } : {}),
+    ...(event.telemetry?.modelId ? { model_id: event.telemetry.modelId } : {}),
+  };
 
   switch (event.hook_event_name) {
     case "MCPConnectionFailed": {
@@ -86,6 +91,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "error",
         message: `MCP server '${event.server_name}' failed to connect: ${event.error.message}`,
         metadata: {
+          ...executionMetadata,
           server_name: event.server_name,
           config_type: event.config.type,
           error_name: event.error.name,
@@ -102,6 +108,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "info",
         message: `MCP server '${event.server_name}' connected successfully with ${event.tool_count} tools`,
         metadata: {
+          ...executionMetadata,
           server_name: event.server_name,
           tool_count: event.tool_count,
         },
@@ -116,6 +123,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "info",
         message: `Tool '${event.tool_name}' registered${event.source ? ` from ${event.source}` : ""}`,
         metadata: {
+          ...executionMetadata,
           tool_name: event.tool_name,
           description: event.description,
           source: event.source,
@@ -131,6 +139,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "warning",
         message: `Failed to load tool '${event.tool_name}': ${event.error.message}`,
         metadata: {
+          ...executionMetadata,
           tool_name: event.tool_name,
           error_name: event.error.name,
           error_message: event.error.message,
@@ -147,6 +156,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "info",
         message: `Context compaction started: ${event.message_count} messages, ${event.tokens_before} tokens`,
         metadata: {
+          ...executionMetadata,
           message_count: event.message_count,
           tokens_before: event.tokens_before,
         },
@@ -165,6 +175,7 @@ export function toStructuredEvent(event: ObservabilityEvent): StructuredEvent {
         severity: "info",
         message: `Context compaction completed: ${event.messages_before} → ${event.messages_after} messages, saved ${event.tokens_saved} tokens (${reductionPercent}%)`,
         metadata: {
+          ...executionMetadata,
           messages_before: event.messages_before,
           messages_after: event.messages_after,
           tokens_before: event.tokens_before,

--- a/packages/agent-sdk/src/observability/execution-metadata.ts
+++ b/packages/agent-sdk/src/observability/execution-metadata.ts
@@ -26,10 +26,24 @@ interface BuildExecutionTelemetryOptions {
 /**
  * Creates a stable execution/run identifier.
  *
+ * @returns A unique run identifier containing a timestamp and random suffix
+ *
  * @category Observability
  */
 export function createRunId(): string {
   return `run_${Date.now().toString(36)}_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+/**
+ * Creates a composite key for request-scoped observability state.
+ *
+ * @param input - Hook input containing session and optional run metadata
+ * @returns Request correlation key
+ *
+ * @internal
+ */
+export function requestKey(input: { session_id: string; telemetry?: { runId?: string } }): string {
+  return `${input.session_id}:${input.telemetry?.runId ?? "run_unknown"}`;
 }
 
 /**
@@ -177,6 +191,7 @@ export function normalizeExecutionUsage(
   };
 }
 
+/** @internal */
 function identityFromModelId(modelId: string | undefined): ResolvedModelIdentity {
   if (!modelId) {
     return {};
@@ -189,10 +204,12 @@ function identityFromModelId(modelId: string | undefined): ResolvedModelIdentity
   };
 }
 
+/** @internal */
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
+/** @internal */
 function firstNumber(...values: unknown[]): number | undefined {
   for (const value of values) {
     if (typeof value === "number" && Number.isFinite(value)) {

--- a/packages/agent-sdk/src/observability/execution-metadata.ts
+++ b/packages/agent-sdk/src/observability/execution-metadata.ts
@@ -1,0 +1,203 @@
+/**
+ * Execution metadata helpers for observability and correlation.
+ *
+ * @packageDocumentation
+ */
+
+import type { LanguageModel, LanguageModelUsage } from "ai";
+import type { ExecutionTelemetry, ExecutionUsageTelemetry } from "../types.js";
+
+interface ResolvedModelIdentity {
+  modelId?: string;
+  provider?: string;
+}
+
+interface BuildExecutionTelemetryOptions {
+  runId: string;
+  threadId?: string;
+  requestedModel?: LanguageModel;
+  responseModelId?: string;
+  usage?: LanguageModelUsage;
+  providerMetadata?: unknown;
+  durationMs?: number;
+  timeToFirstTokenMs?: number;
+}
+
+/**
+ * Creates a stable execution/run identifier.
+ *
+ * @category Observability
+ */
+export function createRunId(): string {
+  return `run_${Date.now().toString(36)}_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+/**
+ * Extracts a telemetry-safe model identifier from a language model.
+ *
+ * @param model - Requested model
+ * @returns Resolved identifier/provider metadata
+ *
+ * @category Observability
+ */
+export function resolveModelIdentity(model: LanguageModel | undefined): ResolvedModelIdentity {
+  if (!model) {
+    return {};
+  }
+
+  if (typeof model === "string") {
+    return identityFromModelId(model);
+  }
+
+  const maybeModel = model as {
+    modelId?: string;
+    provider?: string;
+    providerId?: string;
+  };
+
+  if (typeof maybeModel.modelId === "string") {
+    const identity = identityFromModelId(maybeModel.modelId);
+    return {
+      modelId: maybeModel.modelId,
+      provider:
+        typeof maybeModel.provider === "string"
+          ? maybeModel.provider
+          : typeof maybeModel.providerId === "string"
+            ? maybeModel.providerId
+            : identity.provider,
+    };
+  }
+
+  const stringified = String(model);
+  if (stringified && stringified !== "[object Object]") {
+    return identityFromModelId(stringified);
+  }
+
+  return {};
+}
+
+/**
+ * Builds normalized execution metadata for results, hooks, logs, and spans.
+ *
+ * @param options - Source metadata
+ * @returns Execution telemetry object
+ *
+ * @category Observability
+ */
+export function buildExecutionTelemetry(
+  options: BuildExecutionTelemetryOptions,
+): ExecutionTelemetry {
+  const requested = resolveModelIdentity(options.requestedModel);
+  const response = identityFromModelId(options.responseModelId);
+  const usage = normalizeExecutionUsage(options.usage, options.providerMetadata);
+  const outputTokensPerSecond =
+    options.durationMs && options.durationMs > 0 && usage.outputTokens !== undefined
+      ? Number(((usage.outputTokens / options.durationMs) * 1000).toFixed(3))
+      : undefined;
+
+  return {
+    runId: options.runId,
+    threadId: options.threadId,
+    requestedModelId: requested.modelId,
+    requestedModelProvider: requested.provider,
+    modelId: response.modelId ?? requested.modelId,
+    modelProvider: response.provider ?? requested.provider,
+    durationMs: options.durationMs,
+    timeToFirstTokenMs: options.timeToFirstTokenMs,
+    outputTokensPerSecond,
+    usage,
+  };
+}
+
+/**
+ * Builds a lightweight telemetry object when only identifiers are known.
+ *
+ * @param options - Identifier metadata
+ * @returns Execution telemetry
+ *
+ * @category Observability
+ */
+export function buildExecutionTelemetryFromIds(options: {
+  runId: string;
+  threadId?: string;
+  requestedModel?: LanguageModel;
+}): ExecutionTelemetry {
+  return buildExecutionTelemetry({
+    runId: options.runId,
+    threadId: options.threadId,
+    requestedModel: options.requestedModel,
+  });
+}
+
+/**
+ * Normalizes token usage for telemetry consumers.
+ *
+ * @param usage - Raw AI SDK usage object
+ * @param providerMetadata - Optional provider metadata
+ * @returns Flattened usage telemetry
+ *
+ * @category Observability
+ */
+export function normalizeExecutionUsage(
+  usage?: LanguageModelUsage,
+  providerMetadata?: unknown,
+): ExecutionUsageTelemetry {
+  const usageWithDetails = usage as
+    | (LanguageModelUsage & {
+        inputTokenDetails?: Record<string, unknown>;
+        outputTokenDetails?: Record<string, unknown>;
+      })
+    | undefined;
+
+  const providerRecord = asRecord(providerMetadata);
+  const anthropicUsage = asRecord(providerRecord?.anthropic)?.usage;
+  const anthropicUsageRecord = asRecord(anthropicUsage);
+  const inputDetails = asRecord(usageWithDetails?.inputTokenDetails);
+
+  return {
+    inputTokens: usage?.inputTokens,
+    outputTokens: usage?.outputTokens,
+    totalTokens:
+      usage?.totalTokens ??
+      (usage?.inputTokens !== undefined && usage?.outputTokens !== undefined
+        ? usage.inputTokens + usage.outputTokens
+        : undefined),
+    cacheCreationInputTokens: firstNumber(
+      inputDetails?.cacheCreationInputTokens,
+      inputDetails?.cache_creation_input_tokens,
+      anthropicUsageRecord?.cacheCreationInputTokens,
+      anthropicUsageRecord?.cache_creation_input_tokens,
+    ),
+    cacheReadInputTokens: firstNumber(
+      inputDetails?.cacheReadInputTokens,
+      inputDetails?.cache_read_input_tokens,
+      anthropicUsageRecord?.cacheReadInputTokens,
+      anthropicUsageRecord?.cache_read_input_tokens,
+    ),
+  };
+}
+
+function identityFromModelId(modelId: string | undefined): ResolvedModelIdentity {
+  if (!modelId) {
+    return {};
+  }
+
+  const [provider] = modelId.split("/", 1);
+  return {
+    modelId,
+    provider: modelId.includes("/") ? provider : undefined,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/packages/agent-sdk/src/observability/index.ts
+++ b/packages/agent-sdk/src/observability/index.ts
@@ -135,6 +135,9 @@ export {
 
 // Tracing
 export {
+  createTracingHooks,
+} from "./tracing-hooks.js";
+export {
   createCallbackSpanExporter,
   // Exporters
   createConsoleSpanExporter,

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -765,12 +765,21 @@ export function createMetricsHooks(metrics: AgentMetrics): {
   PostCompact: HookCallback;
   SubagentStart: HookCallback;
 } {
-  const requestStartTimes = new Map<string, number>();
+  const requestStartTimes = new Map<string, { startedAt: number; labels: MetricLabels }>();
   const toolStartTimes = new Map<string, number>();
   const compactionStartTimes = new Map<string, number>();
   const isFiniteNumber = (value: unknown): value is number =>
     typeof value === "number" && Number.isFinite(value);
   const staleTimingTtlMs = Number(process.env.AGENT_SDK_METRICS_TIMING_TTL_MS ?? 300000);
+
+  const pruneStaleRequestStartTimes = (maxAgeMs = staleTimingTtlMs): void => {
+    const now = Date.now();
+    for (const [key, entry] of requestStartTimes) {
+      if (now - entry.startedAt > maxAgeMs) {
+        requestStartTimes.delete(key);
+      }
+    }
+  };
 
   const pruneStaleStartTimes = (map: Map<string, number>, maxAgeMs = staleTimingTtlMs): void => {
     const now = Date.now();
@@ -782,7 +791,7 @@ export function createMetricsHooks(metrics: AgentMetrics): {
   };
 
   const pruneAllStartTimes = (): void => {
-    pruneStaleStartTimes(requestStartTimes);
+    pruneStaleRequestStartTimes();
     pruneStaleStartTimes(toolStartTimes);
     pruneStaleStartTimes(compactionStartTimes);
   };
@@ -813,7 +822,7 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       pruneAllStartTimes();
       const preGenInput = input as PreGenerateInput;
       const labels = labelsFor(preGenInput);
-      requestStartTimes.set(requestKey(preGenInput), Date.now());
+      requestStartTimes.set(requestKey(preGenInput), { startedAt: Date.now(), labels });
       metrics.requestsInProgress.inc(1, labels);
       return {};
     },
@@ -826,10 +835,10 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       metrics.requestsTotal.inc(1, labels);
 
       const key = requestKey(postGenInput);
-      const startedAt = requestStartTimes.get(key);
-      if (startedAt !== undefined) {
-        metrics.requestsInProgress.dec(1, labels);
-        metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
+      const started = requestStartTimes.get(key);
+      if (started) {
+        metrics.requestsInProgress.dec(1, started.labels);
+        metrics.requestDurationMs.observe(Date.now() - started.startedAt, labels);
         requestStartTimes.delete(key);
       } else if (postGenInput.result.telemetry?.durationMs !== undefined) {
         metrics.requestDurationMs.observe(postGenInput.result.telemetry.durationMs, labels);
@@ -894,10 +903,10 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       if (retryInput.decision !== "retry" && retryInput.decision !== "fallback") {
         const labels = labelsFor(retryInput);
         const key = requestKey(retryInput);
-        const startedAt = requestStartTimes.get(key);
-        if (startedAt !== undefined) {
-          metrics.requestsInProgress.dec(1, labels);
-          metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
+        const started = requestStartTimes.get(key);
+        if (started) {
+          metrics.requestsInProgress.dec(1, started.labels);
+          metrics.requestDurationMs.observe(Date.now() - started.startedAt, labels);
           requestStartTimes.delete(key);
         }
         return {};

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -601,14 +601,30 @@ export interface AgentMetrics {
   tokensTotal: Counter;
   /** Tool calls made */
   toolCallsTotal: Counter;
+  /** Tool execution duration in milliseconds */
+  toolDurationMs: Histogram;
   /** Tool call errors */
   toolErrorsTotal: Counter;
   /** Subagent spawns */
   subagentSpawnsTotal: Counter;
   /** Errors by type */
   errorsTotal: Counter;
+  /** Retry attempts by classification */
+  retryAttemptsTotal: Counter;
+  /** Rate-limit errors */
+  rateLimitErrorsTotal: Counter;
   /** Context compactions */
   compactionsTotal: Counter;
+  /** Context compaction duration in milliseconds */
+  compactionDurationMs: Histogram;
+  /** Prompt cache write tokens */
+  cacheCreationInputTokensTotal: Counter;
+  /** Prompt cache read tokens */
+  cacheReadInputTokensTotal: Counter;
+  /** Streaming time-to-first-token in milliseconds */
+  streamTimeToFirstTokenMs: Histogram;
+  /** Streaming output throughput in tokens/sec */
+  streamOutputTokensPerSecond: Histogram;
   /** Checkpoint operations */
   checkpointsTotal: Counter;
 }
@@ -652,10 +668,43 @@ export function createAgentMetrics(registry: MetricsRegistry): AgentMetrics {
     outputTokensTotal: registry.counter("agent_output_tokens_total", "Total output tokens used"),
     tokensTotal: registry.counter("agent_tokens_total", "Total tokens used (input + output)"),
     toolCallsTotal: registry.counter("agent_tool_calls_total", "Total tool calls made"),
+    toolDurationMs: registry.histogram(
+      "agent_tool_duration_ms",
+      DEFAULT_LATENCY_BUCKETS,
+      "Tool execution duration in milliseconds",
+    ),
     toolErrorsTotal: registry.counter("agent_tool_errors_total", "Total tool call errors"),
     subagentSpawnsTotal: registry.counter("agent_subagent_spawns_total", "Total subagent spawns"),
     errorsTotal: registry.counter("agent_errors_total", "Total errors by type"),
+    retryAttemptsTotal: registry.counter("agent_retry_attempts_total", "Total retry attempts"),
+    rateLimitErrorsTotal: registry.counter(
+      "agent_rate_limit_errors_total",
+      "Total rate-limit and overload errors",
+    ),
     compactionsTotal: registry.counter("agent_compactions_total", "Total context compactions"),
+    compactionDurationMs: registry.histogram(
+      "agent_compaction_duration_ms",
+      DEFAULT_LATENCY_BUCKETS,
+      "Context compaction duration in milliseconds",
+    ),
+    cacheCreationInputTokensTotal: registry.counter(
+      "agent_cache_creation_input_tokens_total",
+      "Total prompt-cache write tokens",
+    ),
+    cacheReadInputTokensTotal: registry.counter(
+      "agent_cache_read_input_tokens_total",
+      "Total prompt-cache read tokens",
+    ),
+    streamTimeToFirstTokenMs: registry.histogram(
+      "agent_stream_ttft_ms",
+      DEFAULT_LATENCY_BUCKETS,
+      "Streaming time-to-first-token in milliseconds",
+    ),
+    streamOutputTokensPerSecond: registry.histogram(
+      "agent_stream_output_tokens_per_second",
+      DEFAULT_TOKEN_BUCKETS,
+      "Streaming output throughput in tokens per second",
+    ),
     checkpointsTotal: registry.counter("agent_checkpoints_total", "Total checkpoint operations"),
   };
 }
@@ -665,11 +714,17 @@ export function createAgentMetrics(registry: MetricsRegistry): AgentMetrics {
 // =============================================================================
 
 import type {
+  GenerationRetryDecisionInput,
   HookCallback,
   PostCompactInput,
+  PostGenerateFailureInput,
   PostGenerateInput,
   PostToolUseFailureInput,
   PostToolUseInput,
+  PreCompactInput,
+  PreGenerateInput,
+  PreToolUseInput,
+  SubagentStartInput,
 } from "../types.js";
 
 /**
@@ -698,55 +753,209 @@ import type {
  * @category Observability
  */
 export function createMetricsHooks(metrics: AgentMetrics): {
+  PreGenerate: HookCallback;
   PostGenerate: HookCallback;
+  PostGenerateFailure: HookCallback;
+  GenerationRetryDecision: HookCallback;
+  PreCompact: HookCallback;
+  PreToolUse: HookCallback;
   PostToolUse: HookCallback;
   PostToolUseFailure: HookCallback;
   PostCompact: HookCallback;
+  SubagentStart: HookCallback;
 } {
+  const requestStartTimes = new Map<string, number>();
+  const toolStartTimes = new Map<string, number>();
+  const compactionStartTimes = new Map<string, number>();
+
+  const labelsFor = (input: {
+    telemetry?: {
+      modelId?: string;
+      requestedModelId?: string;
+      modelProvider?: string;
+      requestedModelProvider?: string;
+    };
+    options?: { requestClass?: string };
+  }): MetricLabels => {
+    const labels: MetricLabels = {};
+    const modelId = input.telemetry?.modelId ?? input.telemetry?.requestedModelId;
+    const provider =
+      input.telemetry?.modelProvider ?? input.telemetry?.requestedModelProvider ?? undefined;
+    if (modelId) labels.model = modelId;
+    if (provider) labels.provider = provider;
+    if (input.options?.requestClass) labels.request_class = input.options.requestClass;
+    return labels;
+  };
+
+  const requestKey = (input: { session_id: string; telemetry?: { runId?: string } }): string =>
+    `${input.session_id}:${input.telemetry?.runId ?? "run_unknown"}`;
+
   return {
+    PreGenerate: async (input) => {
+      if (input.hook_event_name !== "PreGenerate") return {};
+      const preGenInput = input as PreGenerateInput;
+      const labels = labelsFor(preGenInput);
+      requestStartTimes.set(requestKey(preGenInput), Date.now());
+      metrics.requestsInProgress.inc(1, labels);
+      return {};
+    },
+
     PostGenerate: async (input) => {
       if (input.hook_event_name !== "PostGenerate") return {};
       const postGenInput = input as PostGenerateInput;
+      const labels = labelsFor(postGenInput);
 
-      metrics.requestsTotal.inc();
+      metrics.requestsTotal.inc(1, labels);
+      metrics.requestsInProgress.dec(1, labels);
+
+      const startedAt = requestStartTimes.get(requestKey(postGenInput));
+      if (startedAt !== undefined) {
+        metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
+        requestStartTimes.delete(requestKey(postGenInput));
+      } else if (postGenInput.result.telemetry?.durationMs !== undefined) {
+        metrics.requestDurationMs.observe(postGenInput.result.telemetry.durationMs, labels);
+      }
 
       if (postGenInput.result.usage) {
-        metrics.inputTokensTotal.inc(postGenInput.result.usage.inputTokens);
-        metrics.outputTokensTotal.inc(postGenInput.result.usage.outputTokens);
-        metrics.tokensTotal.inc(postGenInput.result.usage.totalTokens);
+        metrics.inputTokensTotal.inc(postGenInput.result.usage.inputTokens, labels);
+        metrics.outputTokensTotal.inc(postGenInput.result.usage.outputTokens, labels);
+        metrics.tokensTotal.inc(postGenInput.result.usage.totalTokens, labels);
+      }
+
+      const usageTelemetry = postGenInput.result.telemetry?.usage;
+      if (usageTelemetry?.cacheCreationInputTokens !== undefined) {
+        metrics.cacheCreationInputTokensTotal.inc(usageTelemetry.cacheCreationInputTokens, labels);
+      }
+      if (usageTelemetry?.cacheReadInputTokens !== undefined) {
+        metrics.cacheReadInputTokensTotal.inc(usageTelemetry.cacheReadInputTokens, labels);
+      }
+      if (postGenInput.result.telemetry?.timeToFirstTokenMs !== undefined) {
+        metrics.streamTimeToFirstTokenMs.observe(
+          postGenInput.result.telemetry.timeToFirstTokenMs,
+          labels,
+        );
+      }
+      if (postGenInput.result.telemetry?.outputTokensPerSecond !== undefined) {
+        metrics.streamOutputTokensPerSecond.observe(
+          postGenInput.result.telemetry.outputTokensPerSecond,
+          labels,
+        );
       }
 
       return {};
     },
 
-    PostToolUse: async (input) => {
-      if (input.hook_event_name !== "PostToolUse") return {};
-      const postToolInput = input as PostToolUseInput;
+    PostGenerateFailure: async (input) => {
+      if (input.hook_event_name !== "PostGenerateFailure") return {};
+      const failureInput = input as PostGenerateFailureInput;
+      const labels = labelsFor(failureInput);
 
-      metrics.toolCallsTotal.inc(1, { tool: postToolInput.tool_name });
+      metrics.requestsInProgress.dec(1, labels);
+      metrics.errorsTotal.inc(1, {
+        ...labels,
+        type: failureInput.failureClassification?.type ?? "generation_error",
+      });
+
+      const startedAt = requestStartTimes.get(requestKey(failureInput));
+      if (startedAt !== undefined) {
+        metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
+        requestStartTimes.delete(requestKey(failureInput));
+      }
+
+      if (failureInput.failureClassification?.type === "overload") {
+        metrics.rateLimitErrorsTotal.inc(1, labels);
+      }
 
       return {};
     },
 
-    PostToolUseFailure: async (input) => {
+    GenerationRetryDecision: async (input) => {
+      if (input.hook_event_name !== "GenerationRetryDecision") return {};
+      const retryInput = input as GenerationRetryDecisionInput;
+      if (retryInput.decision !== "retry" && retryInput.decision !== "fallback") {
+        return {};
+      }
+
+      metrics.retryAttemptsTotal.inc(1, {
+        ...labelsFor(retryInput),
+        decision: retryInput.decision,
+        failure_type: retryInput.failureClassification.type,
+      });
+      return {};
+    },
+
+    PreCompact: async (input) => {
+      if (input.hook_event_name !== "PreCompact") return {};
+      const preCompactInput = input as PreCompactInput;
+      compactionStartTimes.set(requestKey(preCompactInput), Date.now());
+      return {};
+    },
+
+    PreToolUse: async (input, toolUseId) => {
+      if (input.hook_event_name !== "PreToolUse") return {};
+      const _preToolInput = input as PreToolUseInput;
+      if (toolUseId) {
+        toolStartTimes.set(toolUseId, Date.now());
+      }
+      return {};
+    },
+
+    PostToolUse: async (input, toolUseId) => {
+      if (input.hook_event_name !== "PostToolUse") return {};
+      const postToolInput = input as PostToolUseInput;
+      const labels = {
+        ...labelsFor(postToolInput),
+        tool: postToolInput.tool_name,
+      };
+
+      metrics.toolCallsTotal.inc(1, labels);
+      if (toolUseId && toolStartTimes.has(toolUseId)) {
+        metrics.toolDurationMs.observe(Date.now() - (toolStartTimes.get(toolUseId) ?? 0), labels);
+        toolStartTimes.delete(toolUseId);
+      }
+
+      return {};
+    },
+
+    PostToolUseFailure: async (input, toolUseId) => {
       if (input.hook_event_name !== "PostToolUseFailure") return {};
       const failureInput = input as PostToolUseFailureInput;
+      const labels = {
+        ...labelsFor(failureInput),
+        tool: failureInput.tool_name,
+      };
 
-      metrics.toolErrorsTotal.inc(1, { tool: failureInput.tool_name });
-      metrics.errorsTotal.inc(1, { type: "tool_error" });
+      metrics.toolErrorsTotal.inc(1, labels);
+      metrics.errorsTotal.inc(1, { ...labels, type: "tool_error" });
+      if (toolUseId) {
+        toolStartTimes.delete(toolUseId);
+      }
 
       return {};
     },
 
     PostCompact: async (input) => {
       if (input.hook_event_name !== "PostCompact") return {};
-      const _postCompactInput = input as PostCompactInput;
+      const postCompactInput = input as PostCompactInput;
+      const labels = labelsFor(postCompactInput);
 
-      metrics.compactionsTotal.inc();
+      metrics.compactionsTotal.inc(1, labels);
+      const startedAt = compactionStartTimes.get(requestKey(postCompactInput));
+      if (startedAt !== undefined) {
+        metrics.compactionDurationMs.observe(Date.now() - startedAt, labels);
+        compactionStartTimes.delete(requestKey(postCompactInput));
+      }
 
-      // Note: Could add additional metrics here like tokens_saved gauge
-      // but keeping it simple for now - the hook input has all the data
-      // if users want to track more granular metrics
+      return {};
+    },
+
+    SubagentStart: async (input) => {
+      if (input.hook_event_name !== "SubagentStart") return {};
+      const subagentInput = input as SubagentStartInput;
+      metrics.subagentSpawnsTotal.inc(1, {
+        ...labelsFor(subagentInput),
+        agent_type: subagentInput.agent_type,
+      });
 
       return {};
     },

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -726,6 +726,7 @@ import type {
   PreToolUseInput,
   SubagentStartInput,
 } from "../types.js";
+import { requestKey } from "./execution-metadata.js";
 
 /**
  * Creates hooks that automatically update agent metrics.
@@ -779,16 +780,12 @@ export function createMetricsHooks(metrics: AgentMetrics): {
   }): MetricLabels => {
     const labels: MetricLabels = {};
     const modelId = input.telemetry?.modelId ?? input.telemetry?.requestedModelId;
-    const provider =
-      input.telemetry?.modelProvider ?? input.telemetry?.requestedModelProvider ?? undefined;
+    const provider = input.telemetry?.modelProvider ?? input.telemetry?.requestedModelProvider;
     if (modelId) labels.model = modelId;
     if (provider) labels.provider = provider;
     if (input.options?.requestClass) labels.request_class = input.options.requestClass;
     return labels;
   };
-
-  const requestKey = (input: { session_id: string; telemetry?: { runId?: string } }): string =>
-    `${input.session_id}:${input.telemetry?.runId ?? "run_unknown"}`;
 
   return {
     PreGenerate: async (input) => {
@@ -862,7 +859,7 @@ export function createMetricsHooks(metrics: AgentMetrics): {
         requestStartTimes.delete(requestKey(failureInput));
       }
 
-      if (failureInput.failureClassification?.type === "overload") {
+      if (failureInput.failureClassification?.subtype === "rate_limit") {
         metrics.rateLimitErrorsTotal.inc(1, labels);
       }
 

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -876,20 +876,10 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       const failureInput = input as PostGenerateFailureInput;
       const labels = labelsFor(failureInput);
 
-      const key = requestKey(failureInput);
-      const startedAt = requestStartTimes.get(key);
-      if (startedAt !== undefined) {
-        metrics.requestsInProgress.dec(1, labels);
-      }
       metrics.errorsTotal.inc(1, {
         ...labels,
         type: failureInput.failureClassification?.type ?? "generation_error",
       });
-
-      if (startedAt !== undefined) {
-        metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
-        requestStartTimes.delete(key);
-      }
 
       if (failureInput.failureClassification?.subtype === "rate_limit") {
         metrics.rateLimitErrorsTotal.inc(1, labels);
@@ -902,6 +892,14 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       if (input.hook_event_name !== "GenerationRetryDecision") return {};
       const retryInput = input as GenerationRetryDecisionInput;
       if (retryInput.decision !== "retry" && retryInput.decision !== "fallback") {
+        const labels = labelsFor(retryInput);
+        const key = requestKey(retryInput);
+        const startedAt = requestStartTimes.get(key);
+        if (startedAt !== undefined) {
+          metrics.requestsInProgress.dec(1, labels);
+          metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
+          requestStartTimes.delete(key);
+        }
         return {};
       }
 

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -768,6 +768,8 @@ export function createMetricsHooks(metrics: AgentMetrics): {
   const requestStartTimes = new Map<string, number>();
   const toolStartTimes = new Map<string, number>();
   const compactionStartTimes = new Map<string, number>();
+  const isFiniteNumber = (value: unknown): value is number =>
+    typeof value === "number" && Number.isFinite(value);
 
   const labelsFor = (input: {
     telemetry?: {
@@ -803,20 +805,28 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       const labels = labelsFor(postGenInput);
 
       metrics.requestsTotal.inc(1, labels);
-      metrics.requestsInProgress.dec(1, labels);
 
-      const startedAt = requestStartTimes.get(requestKey(postGenInput));
+      const key = requestKey(postGenInput);
+      const startedAt = requestStartTimes.get(key);
       if (startedAt !== undefined) {
+        metrics.requestsInProgress.dec(1, labels);
         metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
-        requestStartTimes.delete(requestKey(postGenInput));
+        requestStartTimes.delete(key);
       } else if (postGenInput.result.telemetry?.durationMs !== undefined) {
         metrics.requestDurationMs.observe(postGenInput.result.telemetry.durationMs, labels);
       }
 
       if (postGenInput.result.usage) {
-        metrics.inputTokensTotal.inc(postGenInput.result.usage.inputTokens, labels);
-        metrics.outputTokensTotal.inc(postGenInput.result.usage.outputTokens, labels);
-        metrics.tokensTotal.inc(postGenInput.result.usage.totalTokens, labels);
+        const { inputTokens, outputTokens, totalTokens } = postGenInput.result.usage;
+        if (isFiniteNumber(inputTokens)) {
+          metrics.inputTokensTotal.inc(inputTokens, labels);
+        }
+        if (isFiniteNumber(outputTokens)) {
+          metrics.outputTokensTotal.inc(outputTokens, labels);
+        }
+        if (isFiniteNumber(totalTokens)) {
+          metrics.tokensTotal.inc(totalTokens, labels);
+        }
       }
 
       const usageTelemetry = postGenInput.result.telemetry?.usage;
@@ -847,16 +857,19 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       const failureInput = input as PostGenerateFailureInput;
       const labels = labelsFor(failureInput);
 
-      metrics.requestsInProgress.dec(1, labels);
+      const key = requestKey(failureInput);
+      const startedAt = requestStartTimes.get(key);
+      if (startedAt !== undefined) {
+        metrics.requestsInProgress.dec(1, labels);
+      }
       metrics.errorsTotal.inc(1, {
         ...labels,
         type: failureInput.failureClassification?.type ?? "generation_error",
       });
 
-      const startedAt = requestStartTimes.get(requestKey(failureInput));
       if (startedAt !== undefined) {
         metrics.requestDurationMs.observe(Date.now() - startedAt, labels);
-        requestStartTimes.delete(requestKey(failureInput));
+        requestStartTimes.delete(key);
       }
 
       if (failureInput.failureClassification?.subtype === "rate_limit") {

--- a/packages/agent-sdk/src/observability/metrics.ts
+++ b/packages/agent-sdk/src/observability/metrics.ts
@@ -679,7 +679,7 @@ export function createAgentMetrics(registry: MetricsRegistry): AgentMetrics {
     retryAttemptsTotal: registry.counter("agent_retry_attempts_total", "Total retry attempts"),
     rateLimitErrorsTotal: registry.counter(
       "agent_rate_limit_errors_total",
-      "Total rate-limit and overload errors",
+      'Total rate-limit errors (only incremented for subtype === "rate_limit")',
     ),
     compactionsTotal: registry.counter("agent_compactions_total", "Total context compactions"),
     compactionDurationMs: registry.histogram(
@@ -770,6 +770,22 @@ export function createMetricsHooks(metrics: AgentMetrics): {
   const compactionStartTimes = new Map<string, number>();
   const isFiniteNumber = (value: unknown): value is number =>
     typeof value === "number" && Number.isFinite(value);
+  const staleTimingTtlMs = Number(process.env.AGENT_SDK_METRICS_TIMING_TTL_MS ?? 300000);
+
+  const pruneStaleStartTimes = (map: Map<string, number>, maxAgeMs = staleTimingTtlMs): void => {
+    const now = Date.now();
+    for (const [key, startedAt] of map) {
+      if (now - startedAt > maxAgeMs) {
+        map.delete(key);
+      }
+    }
+  };
+
+  const pruneAllStartTimes = (): void => {
+    pruneStaleStartTimes(requestStartTimes);
+    pruneStaleStartTimes(toolStartTimes);
+    pruneStaleStartTimes(compactionStartTimes);
+  };
 
   const labelsFor = (input: {
     telemetry?: {
@@ -778,20 +794,23 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       modelProvider?: string;
       requestedModelProvider?: string;
     };
+    requestClass?: string;
     options?: { requestClass?: string };
   }): MetricLabels => {
     const labels: MetricLabels = {};
     const modelId = input.telemetry?.modelId ?? input.telemetry?.requestedModelId;
     const provider = input.telemetry?.modelProvider ?? input.telemetry?.requestedModelProvider;
+    const requestClass = input.requestClass ?? input.options?.requestClass;
     if (modelId) labels.model = modelId;
     if (provider) labels.provider = provider;
-    if (input.options?.requestClass) labels.request_class = input.options.requestClass;
+    if (requestClass) labels.request_class = requestClass;
     return labels;
   };
 
   return {
     PreGenerate: async (input) => {
       if (input.hook_event_name !== "PreGenerate") return {};
+      pruneAllStartTimes();
       const preGenInput = input as PreGenerateInput;
       const labels = labelsFor(preGenInput);
       requestStartTimes.set(requestKey(preGenInput), Date.now());
@@ -896,6 +915,7 @@ export function createMetricsHooks(metrics: AgentMetrics): {
 
     PreCompact: async (input) => {
       if (input.hook_event_name !== "PreCompact") return {};
+      pruneAllStartTimes();
       const preCompactInput = input as PreCompactInput;
       compactionStartTimes.set(requestKey(preCompactInput), Date.now());
       return {};
@@ -903,6 +923,7 @@ export function createMetricsHooks(metrics: AgentMetrics): {
 
     PreToolUse: async (input, toolUseId) => {
       if (input.hook_event_name !== "PreToolUse") return {};
+      pruneAllStartTimes();
       const _preToolInput = input as PreToolUseInput;
       if (toolUseId) {
         toolStartTimes.set(toolUseId, Date.now());
@@ -938,6 +959,10 @@ export function createMetricsHooks(metrics: AgentMetrics): {
       metrics.toolErrorsTotal.inc(1, labels);
       metrics.errorsTotal.inc(1, { ...labels, type: "tool_error" });
       if (toolUseId) {
+        const startedAt = toolStartTimes.get(toolUseId);
+        if (startedAt !== undefined) {
+          metrics.toolDurationMs.observe(Date.now() - startedAt, labels);
+        }
         toolStartTimes.delete(toolUseId);
       }
 

--- a/packages/agent-sdk/src/observability/preset.ts
+++ b/packages/agent-sdk/src/observability/preset.ts
@@ -19,6 +19,7 @@ import {
 import {
   type AgentMetrics,
   createAgentMetrics,
+  createMetricsHooks,
   createMetricsRegistry,
   type MetricsRegistry,
   type MetricsRegistryOptions,
@@ -30,6 +31,7 @@ import {
   type Tracer,
   type TracerOptions,
 } from "./tracing.js";
+import { createTracingHooks } from "./tracing-hooks.js";
 
 /**
  * Options for creating an observability preset.
@@ -260,6 +262,59 @@ export function createObservabilityPreset(
         PostToolUseFailure: toolHooks[2] ? [{ hooks: [toolHooks[2]] }] : undefined,
         PreCompact: compactionHooks[0] ? [compactionHooks[0]] : undefined,
         PostCompact: compactionHooks[1] ? [compactionHooks[1]] : undefined,
+      };
+    }
+
+    if (enableMetrics && preset.metrics) {
+      const metricHooks = createMetricsHooks(preset.metrics);
+      hooks = {
+        ...hooks,
+        PreGenerate: [...(hooks?.PreGenerate ?? []), metricHooks.PreGenerate],
+        PostGenerate: [...(hooks?.PostGenerate ?? []), metricHooks.PostGenerate],
+        PostGenerateFailure: [
+          ...(hooks?.PostGenerateFailure ?? []),
+          metricHooks.PostGenerateFailure,
+        ],
+        GenerationRetryDecision: [
+          ...(hooks?.GenerationRetryDecision ?? []),
+          metricHooks.GenerationRetryDecision,
+        ],
+        PreCompact: [...(hooks?.PreCompact ?? []), metricHooks.PreCompact],
+        PostCompact: [...(hooks?.PostCompact ?? []), metricHooks.PostCompact],
+        PreToolUse: [...(hooks?.PreToolUse ?? []), { hooks: [metricHooks.PreToolUse] }],
+        PostToolUse: [...(hooks?.PostToolUse ?? []), { hooks: [metricHooks.PostToolUse] }],
+        PostToolUseFailure: [
+          ...(hooks?.PostToolUseFailure ?? []),
+          { hooks: [metricHooks.PostToolUseFailure] },
+        ],
+        SubagentStart: [...(hooks?.SubagentStart ?? []), metricHooks.SubagentStart],
+      };
+    }
+
+    if (enableTracing && preset.tracer) {
+      const tracingHooks = createTracingHooks(preset.tracer);
+      hooks = {
+        ...hooks,
+        PreGenerate: [...(hooks?.PreGenerate ?? []), tracingHooks.PreGenerate],
+        PostGenerate: [...(hooks?.PostGenerate ?? []), tracingHooks.PostGenerate],
+        PostGenerateFailure: [
+          ...(hooks?.PostGenerateFailure ?? []),
+          tracingHooks.PostGenerateFailure,
+        ],
+        GenerationRetryDecision: [
+          ...(hooks?.GenerationRetryDecision ?? []),
+          tracingHooks.GenerationRetryDecision,
+        ],
+        PreCompact: [...(hooks?.PreCompact ?? []), tracingHooks.PreCompact],
+        PostCompact: [...(hooks?.PostCompact ?? []), tracingHooks.PostCompact],
+        PreToolUse: [...(hooks?.PreToolUse ?? []), { hooks: [tracingHooks.PreToolUse] }],
+        PostToolUse: [...(hooks?.PostToolUse ?? []), { hooks: [tracingHooks.PostToolUse] }],
+        PostToolUseFailure: [
+          ...(hooks?.PostToolUseFailure ?? []),
+          { hooks: [tracingHooks.PostToolUseFailure] },
+        ],
+        SubagentStart: [...(hooks?.SubagentStart ?? []), tracingHooks.SubagentStart],
+        SubagentStop: [...(hooks?.SubagentStop ?? []), tracingHooks.SubagentStop],
       };
     }
 

--- a/packages/agent-sdk/src/observability/tracing-hooks.ts
+++ b/packages/agent-sdk/src/observability/tracing-hooks.ts
@@ -114,6 +114,17 @@ function errorFromUnknown(error: unknown): Error {
   }
 }
 
+/** @internal */
+function errorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string" || typeof error === "number" || typeof error === "boolean") {
+    return String(error);
+  }
+  return undefined;
+}
+
 /**
  * Creates lifecycle hooks that emit tracing spans for generation, tools,
  * compaction, retries, and subagents.
@@ -214,6 +225,7 @@ export function createTracingHooks(tracer: Tracer): {
 
       applyExecutionAttributes(span, failureInput.telemetry);
       span.recordException(failureInput.error);
+      span.setStatus("error", errorMessage(failureInput.error));
       span.end();
       generationSpans.delete(requestKey(failureInput));
       return {};
@@ -272,6 +284,7 @@ export function createTracingHooks(tracer: Tracer): {
 
       const error = errorFromUnknown(failureInput.error);
       span.recordException(error);
+      span.setStatus("error", error.message);
       span.end();
       toolSpans.delete(toolUseId);
       return {};
@@ -340,6 +353,7 @@ export function createTracingHooks(tracer: Tracer): {
 
       if (subagentInput.error) {
         span.recordException(subagentInput.error);
+        span.setStatus("error", subagentInput.error.message);
       } else {
         span.setStatus("ok");
       }

--- a/packages/agent-sdk/src/observability/tracing-hooks.ts
+++ b/packages/agent-sdk/src/observability/tracing-hooks.ts
@@ -1,0 +1,288 @@
+/**
+ * Tracing hooks for agent lifecycle events.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  GenerationRetryDecisionInput,
+  HookCallback,
+  PostCompactInput,
+  PostGenerateFailureInput,
+  PostGenerateInput,
+  PostToolUseFailureInput,
+  PreCompactInput,
+  PreGenerateInput,
+  PreToolUseInput,
+  SubagentStartInput,
+  SubagentStopInput,
+} from "../types.js";
+import { SemanticAttributes, type Span, type SpanContext, type Tracer } from "./tracing.js";
+
+function requestKey(input: { session_id: string; telemetry?: { runId?: string } }): string {
+  return `${input.session_id}:${input.telemetry?.runId ?? "run_unknown"}`;
+}
+
+function spanContext(span: Span): SpanContext {
+  return { traceId: span.traceId, spanId: span.spanId };
+}
+
+function applyExecutionAttributes(
+  span: Span,
+  telemetry:
+    | {
+        runId: string;
+        threadId?: string;
+        requestedModelId?: string;
+        modelId?: string;
+        durationMs?: number;
+        timeToFirstTokenMs?: number;
+        outputTokensPerSecond?: number;
+        usage?: {
+          inputTokens?: number;
+          outputTokens?: number;
+          totalTokens?: number;
+          cacheCreationInputTokens?: number;
+          cacheReadInputTokens?: number;
+        };
+      }
+    | undefined,
+): void {
+  if (!telemetry) return;
+
+  span.setAttribute("agent.run_id", telemetry.runId);
+  if (telemetry.threadId) {
+    span.setAttribute("agent.thread_id", telemetry.threadId);
+  }
+  if (telemetry.requestedModelId) {
+    span.setAttribute(SemanticAttributes.GEN_AI_REQUEST_MODEL, telemetry.requestedModelId);
+  }
+  if (telemetry.modelId) {
+    span.setAttribute(SemanticAttributes.GEN_AI_RESPONSE_MODEL, telemetry.modelId);
+  }
+  if (telemetry.usage?.inputTokens !== undefined) {
+    span.setAttribute(SemanticAttributes.GEN_AI_USAGE_INPUT_TOKENS, telemetry.usage.inputTokens);
+  }
+  if (telemetry.usage?.outputTokens !== undefined) {
+    span.setAttribute(SemanticAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, telemetry.usage.outputTokens);
+  }
+  if (telemetry.timeToFirstTokenMs !== undefined) {
+    span.addEvent("stream.first_token", {
+      "agent.stream.ttft_ms": telemetry.timeToFirstTokenMs,
+    });
+  }
+  if (telemetry.outputTokensPerSecond !== undefined) {
+    span.addEvent("stream.completed", {
+      "agent.stream.output_tokens_per_second": telemetry.outputTokensPerSecond,
+    });
+  }
+  if (telemetry.usage?.cacheCreationInputTokens !== undefined) {
+    span.setAttribute(
+      "gen_ai.usage.cache_creation_input_tokens",
+      telemetry.usage.cacheCreationInputTokens,
+    );
+  }
+  if (telemetry.usage?.cacheReadInputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.cache_read_input_tokens", telemetry.usage.cacheReadInputTokens);
+  }
+}
+
+/**
+ * Creates lifecycle hooks that emit tracing spans for generation, tools,
+ * compaction, retries, and subagents.
+ *
+ * @param tracer - Tracer instance
+ * @returns Hook callbacks for tracing
+ *
+ * @category Observability
+ */
+export function createTracingHooks(tracer: Tracer): {
+  PreGenerate: HookCallback;
+  PostGenerate: HookCallback;
+  PostGenerateFailure: HookCallback;
+  GenerationRetryDecision: HookCallback;
+  PreToolUse: HookCallback;
+  PostToolUse: HookCallback;
+  PostToolUseFailure: HookCallback;
+  PreCompact: HookCallback;
+  PostCompact: HookCallback;
+  SubagentStart: HookCallback;
+  SubagentStop: HookCallback;
+} {
+  const generationSpans = new Map<string, Span>();
+  const toolSpans = new Map<string, Span>();
+  const compactionSpans = new Map<string, Span>();
+  const subagentSpans = new Map<string, Span>();
+
+  return {
+    PreGenerate: async (input) => {
+      if (input.hook_event_name !== "PreGenerate") return {};
+      const preGenInput = input as PreGenerateInput;
+      const span = tracer.startSpan("agent.generate", {
+        kind: "internal",
+        attributes: {
+          [SemanticAttributes.GEN_AI_REQUEST_TEMPERATURE]: preGenInput.options.temperature ?? 0,
+          [SemanticAttributes.GEN_AI_REQUEST_MAX_TOKENS]: preGenInput.options.maxTokens ?? 0,
+          ...(preGenInput.options.requestClass
+            ? { "agent.request_class": preGenInput.options.requestClass }
+            : {}),
+        },
+      });
+      applyExecutionAttributes(span, preGenInput.telemetry);
+      generationSpans.set(requestKey(preGenInput), span);
+      return {};
+    },
+
+    PostGenerate: async (input) => {
+      if (input.hook_event_name !== "PostGenerate") return {};
+      const postGenInput = input as PostGenerateInput;
+      const span = generationSpans.get(requestKey(postGenInput));
+      if (!span) return {};
+
+      applyExecutionAttributes(span, postGenInput.result.telemetry ?? postGenInput.telemetry);
+      span.setAttribute(
+        SemanticAttributes.GEN_AI_RESPONSE_FINISH_REASONS,
+        postGenInput.result.finishReason,
+      );
+      span.setStatus("ok");
+      span.end();
+      generationSpans.delete(requestKey(postGenInput));
+      return {};
+    },
+
+    PostGenerateFailure: async (input) => {
+      if (input.hook_event_name !== "PostGenerateFailure") return {};
+      const failureInput = input as PostGenerateFailureInput;
+      const span = generationSpans.get(requestKey(failureInput));
+      if (!span) return {};
+
+      applyExecutionAttributes(span, failureInput.telemetry);
+      span.recordException(failureInput.error);
+      span.end();
+      generationSpans.delete(requestKey(failureInput));
+      return {};
+    },
+
+    GenerationRetryDecision: async (input) => {
+      if (input.hook_event_name !== "GenerationRetryDecision") return {};
+      const retryInput = input as GenerationRetryDecisionInput;
+      const span = generationSpans.get(requestKey(retryInput));
+      if (!span) return {};
+
+      span.addEvent("generation.retry_decision", {
+        "agent.retry.attempt": retryInput.retryAttempt,
+        "agent.retry.delay_ms": retryInput.retryDelayMs,
+        "agent.retry.decision": retryInput.decision,
+        "agent.retry.failure_type": retryInput.failureClassification.type,
+      });
+      return {};
+    },
+
+    PreToolUse: async (input, toolUseId) => {
+      if (input.hook_event_name !== "PreToolUse" || !toolUseId) return {};
+      const preToolInput = input as PreToolUseInput;
+      const parentSpan = generationSpans.get(requestKey(preToolInput));
+      const span = tracer.startSpan(`tool.${preToolInput.tool_name}`, {
+        parent: parentSpan ? spanContext(parentSpan) : undefined,
+        attributes: {
+          [SemanticAttributes.TOOL_NAME]: preToolInput.tool_name,
+        },
+      });
+      applyExecutionAttributes(span, preToolInput.telemetry);
+      toolSpans.set(toolUseId, span);
+      return {};
+    },
+
+    PostToolUse: async (input, toolUseId) => {
+      if (input.hook_event_name !== "PostToolUse" || !toolUseId) return {};
+      const span = toolSpans.get(toolUseId);
+      if (!span) return {};
+
+      span.setStatus("ok");
+      span.end();
+      toolSpans.delete(toolUseId);
+      return {};
+    },
+
+    PostToolUseFailure: async (input, toolUseId) => {
+      if (input.hook_event_name !== "PostToolUseFailure" || !toolUseId) return {};
+      const failureInput = input as PostToolUseFailureInput;
+      const span = toolSpans.get(toolUseId);
+      if (!span) return {};
+
+      const error =
+        failureInput.error instanceof Error ? failureInput.error : new Error(failureInput.error);
+      span.recordException(error);
+      span.end();
+      toolSpans.delete(toolUseId);
+      return {};
+    },
+
+    PreCompact: async (input) => {
+      if (input.hook_event_name !== "PreCompact") return {};
+      const preCompactInput = input as PreCompactInput;
+      const parentSpan = generationSpans.get(requestKey(preCompactInput));
+      const span = tracer.startSpan("agent.compact", {
+        parent: parentSpan ? spanContext(parentSpan) : undefined,
+        attributes: {
+          "agent.compaction.messages_before": preCompactInput.message_count,
+          "agent.compaction.tokens_before": preCompactInput.tokens_before,
+        },
+      });
+      applyExecutionAttributes(span, preCompactInput.telemetry);
+      compactionSpans.set(requestKey(preCompactInput), span);
+      return {};
+    },
+
+    PostCompact: async (input) => {
+      if (input.hook_event_name !== "PostCompact") return {};
+      const postCompactInput = input as PostCompactInput;
+      const span = compactionSpans.get(requestKey(postCompactInput));
+      if (!span) return {};
+
+      span.setAttributes({
+        "agent.compaction.messages_before": postCompactInput.messages_before,
+        "agent.compaction.messages_after": postCompactInput.messages_after,
+        "agent.compaction.tokens_before": postCompactInput.tokens_before,
+        "agent.compaction.tokens_after": postCompactInput.tokens_after,
+        "agent.compaction.tokens_saved": postCompactInput.tokens_saved,
+      });
+      span.setStatus("ok");
+      span.end();
+      compactionSpans.delete(requestKey(postCompactInput));
+      return {};
+    },
+
+    SubagentStart: async (input) => {
+      if (input.hook_event_name !== "SubagentStart") return {};
+      const subagentInput = input as SubagentStartInput;
+      const parentSpan = generationSpans.get(requestKey(subagentInput));
+      const span = tracer.startSpan(`subagent.${subagentInput.agent_type}`, {
+        parent: parentSpan ? spanContext(parentSpan) : undefined,
+        attributes: {
+          "agent.subagent.id": subagentInput.agent_id,
+          "agent.subagent.type": subagentInput.agent_type,
+        },
+      });
+      applyExecutionAttributes(span, subagentInput.telemetry);
+      subagentSpans.set(subagentInput.agent_id, span);
+      return {};
+    },
+
+    SubagentStop: async (input) => {
+      if (input.hook_event_name !== "SubagentStop") return {};
+      const subagentInput = input as SubagentStopInput;
+      const span = subagentSpans.get(subagentInput.agent_id);
+      if (!span) return {};
+
+      if (subagentInput.error) {
+        span.recordException(subagentInput.error);
+      } else {
+        span.setStatus("ok");
+      }
+      span.end();
+      subagentSpans.delete(subagentInput.agent_id);
+      return {};
+    },
+  };
+}

--- a/packages/agent-sdk/src/observability/tracing-hooks.ts
+++ b/packages/agent-sdk/src/observability/tracing-hooks.ts
@@ -17,37 +17,38 @@ import type {
   SubagentStartInput,
   SubagentStopInput,
 } from "../types.js";
+import { requestKey } from "./execution-metadata.js";
 import { SemanticAttributes, type Span, type SpanContext, type Tracer } from "./tracing.js";
 
-function requestKey(input: { session_id: string; telemetry?: { runId?: string } }): string {
-  return `${input.session_id}:${input.telemetry?.runId ?? "run_unknown"}`;
+interface SpanTelemetryInput {
+  runId: string;
+  threadId?: string;
+  requestedModelId?: string;
+  modelId?: string;
+  durationMs?: number;
+  timeToFirstTokenMs?: number;
+  outputTokensPerSecond?: number;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
+  };
 }
 
+interface ActiveSpan {
+  span: Span;
+  startedAt: number;
+}
+
+/** @internal */
 function spanContext(span: Span): SpanContext {
   return { traceId: span.traceId, spanId: span.spanId };
 }
 
-function applyExecutionAttributes(
-  span: Span,
-  telemetry:
-    | {
-        runId: string;
-        threadId?: string;
-        requestedModelId?: string;
-        modelId?: string;
-        durationMs?: number;
-        timeToFirstTokenMs?: number;
-        outputTokensPerSecond?: number;
-        usage?: {
-          inputTokens?: number;
-          outputTokens?: number;
-          totalTokens?: number;
-          cacheCreationInputTokens?: number;
-          cacheReadInputTokens?: number;
-        };
-      }
-    | undefined,
-): void {
+/** @internal */
+function applyExecutionAttributes(span: Span, telemetry: SpanTelemetryInput | undefined): void {
   if (!telemetry) return;
 
   span.setAttribute("agent.run_id", telemetry.runId);
@@ -87,12 +88,52 @@ function applyExecutionAttributes(
   }
 }
 
+/** @internal */
+function pruneStaleSpans(map: Map<string, ActiveSpan>, maxAgeMs: number): void {
+  const now = Date.now();
+  for (const [key, activeSpan] of map) {
+    if (now - activeSpan.startedAt > maxAgeMs) {
+      activeSpan.span.end();
+      map.delete(key);
+    }
+  }
+}
+
+/** @internal */
+function errorFromUnknown(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === "string" || typeof error === "number" || typeof error === "boolean") {
+    return new Error(String(error));
+  }
+  try {
+    return new Error(JSON.stringify(error));
+  } catch {
+    return new Error("Unknown non-Error value");
+  }
+}
+
 /**
  * Creates lifecycle hooks that emit tracing spans for generation, tools,
  * compaction, retries, and subagents.
  *
  * @param tracer - Tracer instance
  * @returns Hook callbacks for tracing
+ *
+ * @example
+ * ```typescript
+ * import { createAgent, createTracingHooks } from "@lleverage-ai/agent-sdk";
+ *
+ * const tracingHooks = createTracingHooks(tracer);
+ * const agent = createAgent({
+ *   model,
+ *   hooks: {
+ *     PreGenerate: [tracingHooks.PreGenerate],
+ *     PostGenerate: [tracingHooks.PostGenerate],
+ *   },
+ * });
+ * ```
  *
  * @category Observability
  */
@@ -109,35 +150,49 @@ export function createTracingHooks(tracer: Tracer): {
   SubagentStart: HookCallback;
   SubagentStop: HookCallback;
 } {
-  const generationSpans = new Map<string, Span>();
-  const toolSpans = new Map<string, Span>();
-  const compactionSpans = new Map<string, Span>();
-  const subagentSpans = new Map<string, Span>();
+  const staleSpanTtlMs = Number(process.env.AGENT_SDK_TRACING_SPAN_TTL_MS ?? 300000);
+  const generationSpans = new Map<string, ActiveSpan>();
+  const toolSpans = new Map<string, ActiveSpan>();
+  const compactionSpans = new Map<string, ActiveSpan>();
+  const subagentSpans = new Map<string, ActiveSpan>();
+
+  const pruneAll = () => {
+    pruneStaleSpans(generationSpans, staleSpanTtlMs);
+    pruneStaleSpans(toolSpans, staleSpanTtlMs);
+    pruneStaleSpans(compactionSpans, staleSpanTtlMs);
+    pruneStaleSpans(subagentSpans, staleSpanTtlMs);
+  };
 
   return {
     PreGenerate: async (input) => {
       if (input.hook_event_name !== "PreGenerate") return {};
+      pruneAll();
       const preGenInput = input as PreGenerateInput;
       const span = tracer.startSpan("agent.generate", {
         kind: "internal",
         attributes: {
-          [SemanticAttributes.GEN_AI_REQUEST_TEMPERATURE]: preGenInput.options.temperature ?? 0,
-          [SemanticAttributes.GEN_AI_REQUEST_MAX_TOKENS]: preGenInput.options.maxTokens ?? 0,
+          ...(preGenInput.options.temperature != null
+            ? { [SemanticAttributes.GEN_AI_REQUEST_TEMPERATURE]: preGenInput.options.temperature }
+            : {}),
+          ...(preGenInput.options.maxTokens != null
+            ? { [SemanticAttributes.GEN_AI_REQUEST_MAX_TOKENS]: preGenInput.options.maxTokens }
+            : {}),
           ...(preGenInput.options.requestClass
             ? { "agent.request_class": preGenInput.options.requestClass }
             : {}),
         },
       });
       applyExecutionAttributes(span, preGenInput.telemetry);
-      generationSpans.set(requestKey(preGenInput), span);
+      generationSpans.set(requestKey(preGenInput), { span, startedAt: Date.now() });
       return {};
     },
 
     PostGenerate: async (input) => {
       if (input.hook_event_name !== "PostGenerate") return {};
       const postGenInput = input as PostGenerateInput;
-      const span = generationSpans.get(requestKey(postGenInput));
-      if (!span) return {};
+      const activeSpan = generationSpans.get(requestKey(postGenInput));
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       applyExecutionAttributes(span, postGenInput.result.telemetry ?? postGenInput.telemetry);
       span.setAttribute(
@@ -153,8 +208,9 @@ export function createTracingHooks(tracer: Tracer): {
     PostGenerateFailure: async (input) => {
       if (input.hook_event_name !== "PostGenerateFailure") return {};
       const failureInput = input as PostGenerateFailureInput;
-      const span = generationSpans.get(requestKey(failureInput));
-      if (!span) return {};
+      const activeSpan = generationSpans.get(requestKey(failureInput));
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       applyExecutionAttributes(span, failureInput.telemetry);
       span.recordException(failureInput.error);
@@ -166,8 +222,9 @@ export function createTracingHooks(tracer: Tracer): {
     GenerationRetryDecision: async (input) => {
       if (input.hook_event_name !== "GenerationRetryDecision") return {};
       const retryInput = input as GenerationRetryDecisionInput;
-      const span = generationSpans.get(requestKey(retryInput));
-      if (!span) return {};
+      const activeSpan = generationSpans.get(requestKey(retryInput));
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       span.addEvent("generation.retry_decision", {
         "agent.retry.attempt": retryInput.retryAttempt,
@@ -180,8 +237,9 @@ export function createTracingHooks(tracer: Tracer): {
 
     PreToolUse: async (input, toolUseId) => {
       if (input.hook_event_name !== "PreToolUse" || !toolUseId) return {};
+      pruneAll();
       const preToolInput = input as PreToolUseInput;
-      const parentSpan = generationSpans.get(requestKey(preToolInput));
+      const parentSpan = generationSpans.get(requestKey(preToolInput))?.span;
       const span = tracer.startSpan(`tool.${preToolInput.tool_name}`, {
         parent: parentSpan ? spanContext(parentSpan) : undefined,
         attributes: {
@@ -189,14 +247,15 @@ export function createTracingHooks(tracer: Tracer): {
         },
       });
       applyExecutionAttributes(span, preToolInput.telemetry);
-      toolSpans.set(toolUseId, span);
+      toolSpans.set(toolUseId, { span, startedAt: Date.now() });
       return {};
     },
 
     PostToolUse: async (input, toolUseId) => {
       if (input.hook_event_name !== "PostToolUse" || !toolUseId) return {};
-      const span = toolSpans.get(toolUseId);
-      if (!span) return {};
+      const activeSpan = toolSpans.get(toolUseId);
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       span.setStatus("ok");
       span.end();
@@ -207,11 +266,11 @@ export function createTracingHooks(tracer: Tracer): {
     PostToolUseFailure: async (input, toolUseId) => {
       if (input.hook_event_name !== "PostToolUseFailure" || !toolUseId) return {};
       const failureInput = input as PostToolUseFailureInput;
-      const span = toolSpans.get(toolUseId);
-      if (!span) return {};
+      const activeSpan = toolSpans.get(toolUseId);
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
-      const error =
-        failureInput.error instanceof Error ? failureInput.error : new Error(failureInput.error);
+      const error = errorFromUnknown(failureInput.error);
       span.recordException(error);
       span.end();
       toolSpans.delete(toolUseId);
@@ -220,8 +279,9 @@ export function createTracingHooks(tracer: Tracer): {
 
     PreCompact: async (input) => {
       if (input.hook_event_name !== "PreCompact") return {};
+      pruneAll();
       const preCompactInput = input as PreCompactInput;
-      const parentSpan = generationSpans.get(requestKey(preCompactInput));
+      const parentSpan = generationSpans.get(requestKey(preCompactInput))?.span;
       const span = tracer.startSpan("agent.compact", {
         parent: parentSpan ? spanContext(parentSpan) : undefined,
         attributes: {
@@ -230,15 +290,16 @@ export function createTracingHooks(tracer: Tracer): {
         },
       });
       applyExecutionAttributes(span, preCompactInput.telemetry);
-      compactionSpans.set(requestKey(preCompactInput), span);
+      compactionSpans.set(requestKey(preCompactInput), { span, startedAt: Date.now() });
       return {};
     },
 
     PostCompact: async (input) => {
       if (input.hook_event_name !== "PostCompact") return {};
       const postCompactInput = input as PostCompactInput;
-      const span = compactionSpans.get(requestKey(postCompactInput));
-      if (!span) return {};
+      const activeSpan = compactionSpans.get(requestKey(postCompactInput));
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       span.setAttributes({
         "agent.compaction.messages_before": postCompactInput.messages_before,
@@ -255,8 +316,9 @@ export function createTracingHooks(tracer: Tracer): {
 
     SubagentStart: async (input) => {
       if (input.hook_event_name !== "SubagentStart") return {};
+      pruneAll();
       const subagentInput = input as SubagentStartInput;
-      const parentSpan = generationSpans.get(requestKey(subagentInput));
+      const parentSpan = generationSpans.get(requestKey(subagentInput))?.span;
       const span = tracer.startSpan(`subagent.${subagentInput.agent_type}`, {
         parent: parentSpan ? spanContext(parentSpan) : undefined,
         attributes: {
@@ -265,15 +327,16 @@ export function createTracingHooks(tracer: Tracer): {
         },
       });
       applyExecutionAttributes(span, subagentInput.telemetry);
-      subagentSpans.set(subagentInput.agent_id, span);
+      subagentSpans.set(subagentInput.agent_id, { span, startedAt: Date.now() });
       return {};
     },
 
     SubagentStop: async (input) => {
       if (input.hook_event_name !== "SubagentStop") return {};
       const subagentInput = input as SubagentStopInput;
-      const span = subagentSpans.get(subagentInput.agent_id);
-      if (!span) return {};
+      const activeSpan = subagentSpans.get(subagentInput.agent_id);
+      if (!activeSpan) return {};
+      const { span } = activeSpan;
 
       if (subagentInput.error) {
         span.recordException(subagentInput.error);

--- a/packages/agent-sdk/src/tools/task.ts
+++ b/packages/agent-sdk/src/tools/task.ts
@@ -8,18 +8,22 @@
  * @packageDocumentation
  */
 
-import type { LanguageModel, Tool } from "ai";
+import type { LanguageModel, Tool, ToolExecutionOptions } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
+import { invokeHooksWithTimeout } from "../hooks.js";
 import { createSubagent } from "../subagents.js";
 import type { BackgroundTask, BaseTaskStore } from "../task-store/index.js";
 import { createBackgroundTask, updateBackgroundTask } from "../task-store/index.js";
 import type {
   Agent,
+  ExecutionTelemetry,
   StreamingContext,
   StreamingMetadata,
   SubagentCreateContext,
   SubagentDefinition,
+  SubagentStartInput,
+  SubagentStopInput,
 } from "../types.js";
 
 // =============================================================================
@@ -522,8 +526,11 @@ ${subagentDescriptions}`;
           "Fire-and-forget: start the task in the background and continue the conversation immediately. Only use this for work you do not need before your next important step. If your host surfaces background completions automatically, prefer waiting for that notification rather than polling. For parallel execution where you still need the results before continuing, call the task tool multiple times in the same step instead.",
         ),
     }),
-    execute: async (params) => {
+    execute: async (params, toolOptions?: ToolExecutionOptions) => {
       const { description, subagent_type, max_turns, run_in_background } = params;
+      const executionTelemetry = (
+        toolOptions as { executionTelemetry?: ExecutionTelemetry } | undefined
+      )?.executionTelemetry;
 
       // Find the subagent definition
       const subagentDef = subagents.find((s) => s.type === subagent_type);
@@ -588,6 +595,20 @@ ${subagentDescriptions}`;
 
         // Create the subagent with resolved context
         const subagent = await subagentDef.create(createContext);
+
+        const subagentStartHooks = parentAgent.options.hooks?.SubagentStart ?? [];
+        if (subagentStartHooks.length > 0) {
+          const input: SubagentStartInput = {
+            hook_event_name: "SubagentStart",
+            session_id: executionTelemetry?.threadId ?? "default",
+            cwd: process.cwd(),
+            telemetry: executionTelemetry,
+            agent_id: taskId,
+            agent_type: subagent_type,
+            prompt: description,
+          };
+          await invokeHooksWithTimeout(subagentStartHooks, input, null, parentAgent);
+        }
 
         // Wait for subagent's async initialization (MCP connections, plugin setup)
         await subagent.ready;
@@ -654,6 +675,20 @@ ${subagentDescriptions}`;
           }
         }
 
+        const subagentStopHooks = parentAgent.options.hooks?.SubagentStop ?? [];
+        if (subagentStopHooks.length > 0) {
+          const input: SubagentStopInput = {
+            hook_event_name: "SubagentStop",
+            session_id: executionTelemetry?.threadId ?? "default",
+            cwd: process.cwd(),
+            telemetry: executionTelemetry,
+            agent_id: taskId,
+            agent_type: subagent_type,
+            result: resultText,
+          };
+          await invokeHooksWithTimeout(subagentStopHooks, input, null, parentAgent);
+        }
+
         return resultText;
       };
 
@@ -702,6 +737,20 @@ ${subagentDescriptions}`;
             }
           })
           .catch(async (error) => {
+            const subagentStopHooks = parentAgent.options.hooks?.SubagentStop ?? [];
+            if (subagentStopHooks.length > 0) {
+              const input: SubagentStopInput = {
+                hook_event_name: "SubagentStop",
+                session_id: executionTelemetry?.threadId ?? "default",
+                cwd: process.cwd(),
+                telemetry: executionTelemetry,
+                agent_id: taskId,
+                agent_type: subagent_type,
+                error: error instanceof Error ? error : new Error(String(error)),
+              };
+              await invokeHooksWithTimeout(subagentStopHooks, input, null, parentAgent);
+            }
+
             const errorMessage = error instanceof Error ? error.message : String(error);
             const updates = {
               status: "failed" as const,
@@ -749,6 +798,20 @@ ${subagentDescriptions}`;
           text: resultText,
         };
       } catch (error) {
+        const subagentStopHooks = parentAgent.options.hooks?.SubagentStop ?? [];
+        if (subagentStopHooks.length > 0) {
+          const input: SubagentStopInput = {
+            hook_event_name: "SubagentStop",
+            session_id: executionTelemetry?.threadId ?? "default",
+            cwd: process.cwd(),
+            telemetry: executionTelemetry,
+            agent_id: taskId,
+            agent_type: subagent_type,
+            error: error instanceof Error ? error : new Error(String(error)),
+          };
+          await invokeHooksWithTimeout(subagentStopHooks, input, null, parentAgent);
+        }
+
         const errorMessage = error instanceof Error ? error.message : String(error);
 
         const failedTask = updateBackgroundTask(task, {

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -1925,6 +1925,80 @@ export interface GenerateOptions {
    * @internal
    */
   _skipCompaction?: boolean;
+
+  /**
+   * Internal execution/run identifier used to correlate resumed generations.
+   * @internal
+   */
+  _runId?: string;
+}
+
+/**
+ * Telemetry-safe token usage breakdown for a generation or streamed response.
+ *
+ * This supplements the raw AI SDK {@link LanguageModelUsage} shape with
+ * provider-specific categories that are useful for observability, while staying
+ * stable enough to expose in logs, traces, and structured events.
+ *
+ * @category Observability
+ */
+export interface ExecutionUsageTelemetry {
+  /** Input token count */
+  inputTokens?: number;
+
+  /** Output token count */
+  outputTokens?: number;
+
+  /** Total token count */
+  totalTokens?: number;
+
+  /** Input tokens written into a prompt cache, when the provider exposes them */
+  cacheCreationInputTokens?: number;
+
+  /** Input tokens read from a prompt cache, when the provider exposes them */
+  cacheReadInputTokens?: number;
+}
+
+/**
+ * Correlation and performance metadata for a single agent execution/run.
+ *
+ * `threadId` identifies the long-lived conversation/session, while `runId`
+ * identifies a single execution within that thread. This metadata is suitable
+ * for traces, logs, audit records, and event stores. It should not be used as a
+ * high-cardinality metric label.
+ *
+ * @category Observability
+ */
+export interface ExecutionTelemetry {
+  /** Stable identifier for this execution/run */
+  runId: string;
+
+  /** Conversation/session identifier when available */
+  threadId?: string;
+
+  /** Requested model identifier if known */
+  requestedModelId?: string;
+
+  /** Requested model provider if known */
+  requestedModelProvider?: string;
+
+  /** Model identifier reported by the provider if known */
+  modelId?: string;
+
+  /** Model provider inferred from the model identifier or object if known */
+  modelProvider?: string;
+
+  /** Total execution duration in milliseconds */
+  durationMs?: number;
+
+  /** Streaming time-to-first-token in milliseconds */
+  timeToFirstTokenMs?: number;
+
+  /** Streaming output throughput in tokens/sec */
+  outputTokensPerSecond?: number;
+
+  /** Normalized token usage breakdown */
+  usage?: ExecutionUsageTelemetry;
 }
 
 /**
@@ -1937,6 +2011,9 @@ export interface GenerateOptions {
 export interface GenerateResultComplete {
   /** Status indicating the generation completed successfully */
   status: "complete";
+
+  /** Execution metadata for correlation and observability */
+  telemetry?: ExecutionTelemetry;
 
   /** The generated text */
   text: string;
@@ -1998,6 +2075,9 @@ export interface PartialGenerateResult {
 export interface GenerateResultInterrupted {
   /** Status indicating the generation was interrupted */
   status: "interrupted";
+
+  /** Execution metadata for correlation and observability */
+  telemetry?: ExecutionTelemetry;
 
   /** The interrupt that caused the pause */
   interrupt: Interrupt;
@@ -2545,6 +2625,8 @@ export interface BaseHookInput {
   session_id: string;
   /** Current working directory */
   cwd: string;
+  /** Execution metadata when the SDK can provide it */
+  telemetry?: ExecutionTelemetry;
 }
 
 /**

--- a/packages/agent-sdk/tests/checkpoint-first-interrupt.test.ts
+++ b/packages/agent-sdk/tests/checkpoint-first-interrupt.test.ts
@@ -111,6 +111,7 @@ describe("Checkpoint: interrupt on first generation", () => {
     expect(checkpoint?.threadId).toBe(threadId);
     expect(checkpoint?.pendingInterrupt).toBeDefined();
     expect(checkpoint?.pendingInterrupt?.id).toBe("int_call_first_gen");
+    expect(typeof checkpoint?.metadata?.runId).toBe("string");
   });
 
   it("should allow resume() after interrupt on first generation", async () => {
@@ -222,6 +223,7 @@ describe("Checkpoint: interrupt on first generation", () => {
 
     const checkpointAfterFirst = await checkpointer.load(threadId);
     expect(checkpointAfterFirst).toBeDefined();
+    expect(typeof checkpointAfterFirst?.metadata?.runId).toBe("string");
 
     // Second generation: interrupt updates existing checkpoint
     const secondResult = await agent.generate({ prompt: "Use the tool", threadId });
@@ -230,5 +232,6 @@ describe("Checkpoint: interrupt on first generation", () => {
     const checkpointAfterInterrupt = await checkpointer.load(threadId);
     expect(checkpointAfterInterrupt).toBeDefined();
     expect(checkpointAfterInterrupt?.pendingInterrupt).toBeDefined();
+    expect(typeof checkpointAfterInterrupt?.metadata?.runId).toBe("string");
   });
 });

--- a/packages/agent-sdk/tests/generation-helpers.test.ts
+++ b/packages/agent-sdk/tests/generation-helpers.test.ts
@@ -20,6 +20,9 @@ import type {
 // Mock agent for tests
 const createMockAgent = (): Agent =>
   ({
+    options: {
+      model: createMockModel(),
+    },
     generate: vi.fn(),
     stream: vi.fn(),
     streamResponse: vi.fn(),

--- a/packages/agent-sdk/tests/hooks.test.ts
+++ b/packages/agent-sdk/tests/hooks.test.ts
@@ -2096,6 +2096,11 @@ describe("Additional hook event types", () => {
 // =============================================================================
 
 describe("Hook execution order", () => {
+  beforeEach(() => {
+    resetMocks();
+    vi.clearAllMocks();
+  });
+
   it("executes hooks in registration order", async () => {
     const executionOrder: number[] = [];
 

--- a/packages/agent-sdk/tests/hooks.test.ts
+++ b/packages/agent-sdk/tests/hooks.test.ts
@@ -2266,6 +2266,85 @@ describe("Hook execution order", () => {
 
     expect(events).toEqual(["generate", "post-hook"]);
   });
+
+  it("PreGenerate hooks receive execution telemetry", async () => {
+    const mockGenerate = vi.mocked(generateText);
+    mockGenerate.mockResolvedValue({
+      text: "response",
+      finishReason: "stop",
+      usage: { totalTokens: 10, promptTokens: 5, completionTokens: 5 },
+      steps: [],
+      response: {
+        id: "resp-1",
+        timestamp: new Date(),
+        modelId: "mock-response-model",
+        messages: [],
+      },
+    } as any);
+
+    const preHook: HookCallback = vi.fn().mockResolvedValue({});
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      hooks: {
+        PreGenerate: [preHook],
+      },
+    });
+
+    await agent.generate({ prompt: "test", threadId: "thread-123" });
+
+    const hookInput = vi.mocked(preHook).mock.calls[0]?.[0] as PreGenerateInput;
+    expect(hookInput.telemetry).toBeDefined();
+    expect(hookInput.telemetry?.threadId).toBe("thread-123");
+    expect(hookInput.telemetry?.runId).toBeTruthy();
+    expect(hookInput.telemetry?.requestedModelId).toBe("mock-model");
+    expect(hookInput.telemetry?.modelId).toBe("mock-model");
+  });
+
+  it("generate() results and PostGenerate hooks expose execution telemetry", async () => {
+    const mockGenerate = vi.mocked(generateText);
+    mockGenerate.mockResolvedValue({
+      text: "response",
+      finishReason: "stop",
+      usage: {
+        totalTokens: 12,
+        promptTokens: 5,
+        completionTokens: 7,
+        inputTokens: 5,
+        outputTokens: 7,
+      },
+      steps: [],
+      response: {
+        id: "resp-2",
+        timestamp: new Date(),
+        modelId: "mock-response-model",
+        messages: [],
+      },
+    } as any);
+
+    const postHook: HookCallback = vi.fn().mockResolvedValue({});
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      hooks: {
+        PostGenerate: [postHook],
+      },
+    });
+
+    const result = await agent.generate({ prompt: "test", threadId: "thread-456" });
+
+    expect(result.telemetry).toBeDefined();
+    expect(result.telemetry?.threadId).toBe("thread-456");
+    expect(result.telemetry?.runId).toBeTruthy();
+    expect(result.telemetry?.requestedModelId).toBe("mock-model");
+    expect(result.telemetry?.modelId).toBe("mock-response-model");
+    expect(result.telemetry?.usage?.totalTokens).toBe(12);
+
+    const hookInput = vi.mocked(postHook).mock.calls[0]?.[0] as PostGenerateInput;
+    expect(hookInput.result.telemetry).toEqual(result.telemetry);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

This adds first-class SDK execution telemetry for agent runs and threads, then wires that metadata through the built-in observability stack.

The PR makes `runId` / `threadId` correlation part of the SDK runtime instead of leaving it to app-level conventions, exposes normalized execution telemetry on generation results and hook inputs, adds tracing hook factories and preset wiring for them, and persists run correlation through checkpoint interrupt/resume flows.

## What Changed

### Execution telemetry

- add `ExecutionTelemetry` and `ExecutionUsageTelemetry` public types
- add internal `_runId` propagation on `GenerateOptions` so resumed and follow-up generations can preserve run correlation
- add `telemetry` to complete and interrupted `generate()` results
- add `telemetry` to `BaseHookInput`, so generation, tool, compaction, interrupt, and subagent hooks can correlate activity to a single SDK run
- add `packages/agent-sdk/src/observability/execution-metadata.ts` to:
  - generate stable run IDs
  - resolve requested/response model identity
  - normalize token usage, including prompt cache metadata when providers expose it
  - compute execution timing fields such as duration, TTFT, and output throughput

### Agent runtime and checkpoint behavior

- thread execution telemetry through `generate()`, streaming paths, tool wrapping, compaction hooks, and resume flows
- persist `runId` into checkpoint metadata on normal saves, not just interrupt handling
- reuse the checkpoint `runId` when resuming an interrupted thread so the resumed execution stays correlated to the original run
- avoid reusing stale run IDs for fresh turns by only recovering a stored run ID when resuming an interrupting checkpoint
- propagate execution telemetry into tool execution options so subagent delegation can emit correlated lifecycle hooks

### Observability hooks, logging, metrics, and events

- add `createTracingHooks()` and export it from the public SDK surface
- make `createObservabilityPreset()` auto-register metrics and tracing hooks when those features are enabled, instead of only wiring logging hooks
- enrich built-in logging hooks and logging middleware with run/thread/model metadata
- enrich audit hooks with run/thread/model metadata for generation and tool events
- enrich structured observability events with execution metadata where available
- expand metrics hook coverage to include:
  - request durations
  - retry attempts and overload/rate-limit failures
  - tool durations
  - compaction durations
  - subagent spawns
  - prompt-cache token counters
  - stream TTFT and output throughput

### Tracing coverage

- trace generation lifecycle with request/response model metadata and token usage
- trace retry decisions as generation-span events
- trace tool execution as child spans
- trace compaction as child spans
- trace subagent start/stop as child spans

### Docs and changelog

- document the new execution telemetry contract in `docs/observability.md`
- update `packages/agent-sdk/README.md` feature summary
- add unreleased changelog entries in `CHANGELOG.md`

## Public API Impact

New exports / public surface:

- `ExecutionTelemetry`
- `ExecutionUsageTelemetry`
- `createTracingHooks()`
- `telemetry` on generate results and hook inputs

Behavioral changes:

- `createObservabilityPreset()` now auto-wires metrics and tracing hooks when enabled
- checkpointed interrupt/resume flows retain stable SDK-generated `runId` correlation

## Testing

- `bun run --filter '@lleverage-ai/agent-sdk' type-check`
- `bun run --filter '@lleverage-ai/agent-sdk' test`
- repo pre-push hook also ran successfully:
  - `bun run --filter '@lleverage-ai/agent-threads' build`
  - `bun run --filter '@lleverage-ai/agent-threads' test`
  - `bun run --filter '@lleverage-ai/agent-sdk' test`
- validated changed files with matching Biome CLI:
  - `bunx @biomejs/biome@2.4.4 check ...`

## Notes

- The repo's current `bun run check` command uses a Biome CLI version older than the checked-in schema (`2.3.14` CLI vs `2.4.4` schema). That emits a schema-version info message in this environment, but it did not block the branch push and the changed files were checked successfully with Biome `2.4.4`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class execution telemetry (stable runId/threadId) on results, hooks and logs; built-in tracing hooks now available for correlated spans; observability preset auto-wires logging, metrics and tracing; expanded metrics for tools, retries, rate-limits, cache token and streaming.

* **Documentation**
  * Observability docs updated with new metric names, examples, config patterns and guidance for SDK-generated telemetry.

* **Bug Fixes**
  * Telemetry preserved across resume/background flows; metrics fixes to avoid negative in-progress gauges and token overcounts.

* **Tests**
  * Added tests for telemetry propagation and persisted runId on checkpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->