### PR TITLE
chore(release): prepare agent-sdk alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3] - 2026-04-23
+
 ### Added
 
 - First-class execution telemetry in `@lleverage-ai/agent-sdk`: generation results and hook inputs now carry `telemetry` metadata with `runId`, `threadId`, requested/response model identity, usage, and timing data for reliable per-run correlation

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `@lleverage-ai/agent-sdk` to `0.1.0-alpha.3`
- move current changelog entries into `0.1.0-alpha.3` dated 2026-04-23
- leave `@lleverage-ai/agent-threads` at `0.1.0-alpha.5` because there are no `packages/agent-threads` changes since its last release tag

## Verification
- `bun run build`
- `bun run type-check`
- `bun run check`
- `bun run test`
- push hook reran `biome check .` and full package tests successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.1.0-alpha.3 of the agent SDK package with updated version references across package manifests and release documentation

* **Documentation**
  * Updated changelog documenting the 0.1.0-alpha.3 release, now featuring first-class execution telemetry support and comprehensive tracing hook instrumentation capabilities for enhanced agent visibility and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->