### PR TITLE
[LLE-9203] - Adding required function/tool for agent-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `PreToolUse` hooks now support `respondWith` in `HookSpecificOutput` to short-circuit tool execution and return a synthetic result without calling the original tool. `PostToolUse` hooks still fire with the synthetic result for observability
+- `PreToolUse` hooks now support `respondWith` in `HookSpecificOutput` to short-circuit tool execution and return a synthetic result without calling the original tool. `PostToolUse` hooks still fire with the synthetic result for observability, and the `PostToolUseInput` carries `tool_result_synthetic: true` so audit/log/metrics hooks can distinguish intercepted calls from real ones
 
 ## [0.1.0-alpha.3] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `PreToolUse` hooks now support `respondWith` in `HookSpecificOutput` to short-circuit tool execution and return a synthetic result without calling the original tool. `PostToolUse` hooks still fire with the synthetic result for observability
+
 ## [0.1.0-alpha.3] - 2026-04-23
 
 ### Added

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -723,6 +723,7 @@ function wrapToolsWithHooks(
                 tool_name: name,
                 tool_input: input as Record<string, unknown>,
                 tool_response: respondWithValue,
+                tool_result_synthetic: true,
               };
 
               const postHookOutputs = await invokeMatchingHooks(

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -719,18 +719,24 @@ function wrapToolsWithHooks(
                 hook_event_name: "PostToolUse",
                 session_id: sessionId,
                 cwd: process.cwd(),
+                telemetry,
                 tool_name: name,
                 tool_input: input as Record<string, unknown>,
                 tool_response: respondWithValue,
               };
 
-              await invokeMatchingHooks(
+              const postHookOutputs = await invokeMatchingHooks(
                 hookRegistration.PostToolUse,
                 name,
                 syntheticPostInput,
                 toolUseId,
                 agent,
               );
+
+              const updatedResult = extractUpdatedResult(postHookOutputs);
+              if (updatedResult !== undefined) {
+                return updatedResult;
+              }
             }
 
             return respondWithValue;

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -44,6 +44,7 @@ import {
 } from "./generation-helpers.js";
 import {
   aggregatePermissionDecisions,
+  extractRespondWith,
   extractUpdatedInput,
   extractUpdatedResult,
   invokeHooksWithTimeout,
@@ -708,6 +709,31 @@ function wrapToolsWithHooks(
           const updatedInput = extractUpdatedInput(preHookOutputs);
           if (updatedInput !== undefined) {
             input = updatedInput;
+          }
+
+          // Check for short-circuit via respondWith (skips tool execution)
+          const respondWithValue = extractRespondWith(preHookOutputs);
+          if (respondWithValue !== undefined) {
+            if (hookRegistration?.PostToolUse?.length) {
+              const syntheticPostInput: PostToolUseInput = {
+                hook_event_name: "PostToolUse",
+                session_id: sessionId,
+                cwd: process.cwd(),
+                tool_name: name,
+                tool_input: input as Record<string, unknown>,
+                tool_response: respondWithValue,
+              };
+
+              await invokeMatchingHooks(
+                hookRegistration.PostToolUse,
+                name,
+                syntheticPostInput,
+                toolUseId,
+                agent,
+              );
+            }
+
+            return respondWithValue;
           }
         }
 

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -2653,6 +2653,14 @@ export interface PostToolUseInput extends BaseHookInput {
   tool_input: Record<string, unknown>;
   /** Result from the tool execution */
   tool_response: unknown;
+  /**
+   * `true` when `tool_response` came from a `PreToolUse` `respondWith`
+   * short-circuit rather than the tool's own `execute`. Hooks that
+   * record tool activity (audit logs, metrics, side-effects) can use
+   * this to distinguish intercepted calls from real ones.
+   * @defaultValue undefined
+   */
+  tool_result_synthetic?: boolean;
 }
 
 /**

--- a/packages/agent-sdk/tests/hooks.test.ts
+++ b/packages/agent-sdk/tests/hooks.test.ts
@@ -3306,6 +3306,94 @@ describe("tool lifecycle hooks integration", () => {
     );
   });
 
+  it("PreToolUse respondWith allows PostToolUse to transform the result via updatedResult", async () => {
+    const mockGenerateText = vi.mocked(generateText);
+    const toolExecuteFn = vi.fn().mockResolvedValue("Tool result");
+
+    const { tool } = await import("ai");
+    const { z } = await import("zod");
+    const testTool = tool({
+      description: "A test tool",
+      parameters: z.object({
+        message: z.string(),
+      }),
+      execute: toolExecuteFn,
+    });
+
+    let capturedToolResult: unknown;
+
+    mockGenerateText.mockImplementation(async (params) => {
+      const tools = params.tools || {};
+      if (
+        tools.testTool &&
+        typeof (tools.testTool as { execute?: unknown }).execute === "function"
+      ) {
+        capturedToolResult = await (
+          tools.testTool as { execute: (input: unknown, options: unknown) => Promise<unknown> }
+        ).execute({ message: "hello" }, {});
+      }
+      return {
+        text: "Response",
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 20, inputTokenDetails: {}, outputTokenDetails: {} },
+        response: { id: "test-id", timestamp: new Date(), modelId: "test-model", messages: [] },
+        request: {},
+        warnings: [],
+        providerMetadata: undefined,
+        files: [],
+        sources: [],
+        reasoning: [],
+        reasoningText: undefined,
+        content: [],
+      } as never;
+    });
+
+    const syntheticResult = { content: "raw file" };
+    const transformedResult = { content: "raw file", enriched: true };
+
+    const preToolHook: HookCallback = async (input) => {
+      if (input.hook_event_name === "PreToolUse") {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            respondWith: syntheticResult,
+          },
+        };
+      }
+      return {};
+    };
+
+    const postToolHook: HookCallback = async (input) => {
+      if (input.hook_event_name === "PostToolUse") {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PostToolUse",
+            updatedResult: transformedResult,
+          },
+        };
+      }
+      return {};
+    };
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      tools: { testTool },
+      hooks: {
+        PreToolUse: [{ hooks: [preToolHook] }],
+        PostToolUse: [{ hooks: [postToolHook] }],
+      },
+    });
+
+    await agent.generate({ prompt: "Test" });
+
+    expect(toolExecuteFn).not.toHaveBeenCalled();
+    expect(capturedToolResult).toEqual(transformedResult);
+  });
+
   it("tool hook matcher filters tools by name", async () => {
     const mockGenerateText = vi.mocked(generateText);
 

--- a/packages/agent-sdk/tests/hooks.test.ts
+++ b/packages/agent-sdk/tests/hooks.test.ts
@@ -3300,6 +3300,7 @@ describe("tool lifecycle hooks integration", () => {
         hook_event_name: "PostToolUse",
         tool_name: "testTool",
         tool_response: syntheticResult,
+        tool_result_synthetic: true,
       }),
       expect.any(String),
       expect.any(Object),
@@ -3392,6 +3393,163 @@ describe("tool lifecycle hooks integration", () => {
 
     expect(toolExecuteFn).not.toHaveBeenCalled();
     expect(capturedToolResult).toEqual(transformedResult);
+  });
+
+  it("PreToolUse respondWith forwards updatedInput to PostToolUse tool_input", async () => {
+    const mockGenerateText = vi.mocked(generateText);
+    const toolExecuteFn = vi.fn().mockResolvedValue("Tool result");
+    const postToolHandler = vi.fn().mockResolvedValue({});
+
+    const { tool } = await import("ai");
+    const { z } = await import("zod");
+    const testTool = tool({
+      description: "A test tool",
+      parameters: z.object({
+        message: z.string(),
+      }),
+      execute: toolExecuteFn,
+    });
+
+    mockGenerateText.mockImplementation(async (params) => {
+      const tools = params.tools || {};
+      if (
+        tools.testTool &&
+        typeof (tools.testTool as { execute?: unknown }).execute === "function"
+      ) {
+        await (
+          tools.testTool as { execute: (input: unknown, options: unknown) => Promise<unknown> }
+        ).execute({ message: "original" }, {});
+      }
+      return {
+        text: "Response",
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 20, inputTokenDetails: {}, outputTokenDetails: {} },
+        response: { id: "test-id", timestamp: new Date(), modelId: "test-model", messages: [] },
+        request: {},
+        warnings: [],
+        providerMetadata: undefined,
+        files: [],
+        sources: [],
+        reasoning: [],
+        reasoningText: undefined,
+        content: [],
+      } as never;
+    });
+
+    const preToolHook: HookCallback = async (input) => {
+      if (input.hook_event_name === "PreToolUse") {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            updatedInput: { message: "transformed" },
+            respondWith: "synthetic",
+          },
+        };
+      }
+      return {};
+    };
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      tools: { testTool },
+      hooks: {
+        PreToolUse: [{ hooks: [preToolHook] }],
+        PostToolUse: [{ hooks: [postToolHandler] }],
+      },
+    });
+
+    await agent.generate({ prompt: "Test" });
+
+    expect(toolExecuteFn).not.toHaveBeenCalled();
+    expect(postToolHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hook_event_name: "PostToolUse",
+        tool_input: { message: "transformed" },
+        tool_response: "synthetic",
+      }),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it("PreToolUse permissionDecision 'deny' wins over respondWith from the same hook", async () => {
+    const mockGenerateText = vi.mocked(generateText);
+    const toolExecuteFn = vi.fn().mockResolvedValue("Tool result");
+    const postToolHandler = vi.fn().mockResolvedValue({});
+
+    const { tool } = await import("ai");
+    const { z } = await import("zod");
+    const testTool = tool({
+      description: "A test tool",
+      parameters: z.object({
+        message: z.string(),
+      }),
+      execute: toolExecuteFn,
+    });
+
+    let capturedToolResult: unknown;
+
+    mockGenerateText.mockImplementation(async (params) => {
+      const tools = params.tools || {};
+      if (
+        tools.testTool &&
+        typeof (tools.testTool as { execute?: unknown }).execute === "function"
+      ) {
+        try {
+          capturedToolResult = await (
+            tools.testTool as { execute: (input: unknown, options: unknown) => Promise<unknown> }
+          ).execute({ message: "hello" }, {});
+        } catch {
+          capturedToolResult = "threw";
+        }
+      }
+      return {
+        text: "Response",
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 20, inputTokenDetails: {}, outputTokenDetails: {} },
+        response: { id: "test-id", timestamp: new Date(), modelId: "test-model", messages: [] },
+        request: {},
+        warnings: [],
+        providerMetadata: undefined,
+        files: [],
+        sources: [],
+        reasoning: [],
+        reasoningText: undefined,
+        content: [],
+      } as never;
+    });
+
+    const preToolHandler = vi.fn().mockResolvedValue({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse" as const,
+        permissionDecision: "deny" as const,
+        permissionDecisionReason: "Not allowed",
+        respondWith: "should-be-ignored",
+      },
+    });
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      tools: { testTool },
+      hooks: {
+        PreToolUse: [{ hooks: [preToolHandler] }],
+        PostToolUse: [{ hooks: [postToolHandler] }],
+      },
+    });
+
+    await agent.generate({ prompt: "Test" });
+
+    expect(toolExecuteFn).not.toHaveBeenCalled();
+    expect(postToolHandler).not.toHaveBeenCalled();
+    expect(capturedToolResult).toBe("threw");
   });
 
   it("tool hook matcher filters tools by name", async () => {

--- a/packages/agent-sdk/tests/hooks.test.ts
+++ b/packages/agent-sdk/tests/hooks.test.ts
@@ -3148,6 +3148,164 @@ describe("tool lifecycle hooks integration", () => {
     expect(toolExecuteFn).not.toHaveBeenCalled();
   });
 
+  it("PreToolUse hook can short-circuit execution via respondWith", async () => {
+    const mockGenerateText = vi.mocked(generateText);
+    const toolExecuteFn = vi.fn().mockResolvedValue("Tool result");
+
+    const { tool } = await import("ai");
+    const { z } = await import("zod");
+    const testTool = tool({
+      description: "A test tool",
+      parameters: z.object({
+        message: z.string(),
+      }),
+      execute: toolExecuteFn,
+    });
+
+    let capturedToolResult: unknown;
+
+    mockGenerateText.mockImplementation(async (params) => {
+      const tools = params.tools || {};
+      if (
+        tools.testTool &&
+        typeof (tools.testTool as { execute?: unknown }).execute === "function"
+      ) {
+        capturedToolResult = await (
+          tools.testTool as { execute: (input: unknown, options: unknown) => Promise<unknown> }
+        ).execute({ message: "hello" }, {});
+      }
+      return {
+        text: "Response",
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 20, inputTokenDetails: {}, outputTokenDetails: {} },
+        response: { id: "test-id", timestamp: new Date(), modelId: "test-model", messages: [] },
+        request: {},
+        warnings: [],
+        providerMetadata: undefined,
+        files: [],
+        sources: [],
+        reasoning: [],
+        reasoningText: undefined,
+        content: [],
+      } as never;
+    });
+
+    const syntheticResult = { content: "resolved file content", source: "memory://path" };
+
+    const preToolHandler: HookCallback = async (input) => {
+      if (input.hook_event_name === "PreToolUse") {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            respondWith: syntheticResult,
+          },
+        };
+      }
+      return {};
+    };
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      tools: { testTool },
+      hooks: {
+        PreToolUse: [{ hooks: [preToolHandler] }],
+      },
+    });
+
+    await agent.generate({ prompt: "Test" });
+
+    // Original tool execute should not have been called
+    expect(toolExecuteFn).not.toHaveBeenCalled();
+    // Wrapped execute should return the respondWith value
+    expect(capturedToolResult).toEqual(syntheticResult);
+  });
+
+  it("PreToolUse respondWith still fires PostToolUse hooks", async () => {
+    const mockGenerateText = vi.mocked(generateText);
+    const toolExecuteFn = vi.fn().mockResolvedValue("Tool result");
+    const postToolHandler = vi.fn().mockResolvedValue({});
+
+    const { tool } = await import("ai");
+    const { z } = await import("zod");
+    const testTool = tool({
+      description: "A test tool",
+      parameters: z.object({
+        message: z.string(),
+      }),
+      execute: toolExecuteFn,
+    });
+
+    mockGenerateText.mockImplementation(async (params) => {
+      const tools = params.tools || {};
+      if (
+        tools.testTool &&
+        typeof (tools.testTool as { execute?: unknown }).execute === "function"
+      ) {
+        await (
+          tools.testTool as { execute: (input: unknown, options: unknown) => Promise<unknown> }
+        ).execute({ message: "hello" }, {});
+      }
+      return {
+        text: "Response",
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 20, inputTokenDetails: {}, outputTokenDetails: {} },
+        response: { id: "test-id", timestamp: new Date(), modelId: "test-model", messages: [] },
+        request: {},
+        warnings: [],
+        providerMetadata: undefined,
+        files: [],
+        sources: [],
+        reasoning: [],
+        reasoningText: undefined,
+        content: [],
+      } as never;
+    });
+
+    const syntheticResult = "resolved content";
+
+    const preToolHook: HookCallback = async (input) => {
+      if (input.hook_event_name === "PreToolUse") {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            respondWith: syntheticResult,
+          },
+        };
+      }
+      return {};
+    };
+
+    const model = createMockModel();
+    const agent = createAgent({
+      model,
+      tools: { testTool },
+      hooks: {
+        PreToolUse: [{ hooks: [preToolHook] }],
+        PostToolUse: [{ hooks: [postToolHandler] }],
+      },
+    });
+
+    await agent.generate({ prompt: "Test" });
+
+    expect(toolExecuteFn).not.toHaveBeenCalled();
+    expect(postToolHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hook_event_name: "PostToolUse",
+        tool_name: "testTool",
+        tool_response: syntheticResult,
+      }),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
   it("tool hook matcher filters tools by name", async () => {
     const mockGenerateText = vi.mocked(generateText);
 


### PR DESCRIPTION
## Summary

  - Added respondWith support for PreToolUse hooks in wrapToolsWithHooks. Previously, respondWith on HookSpecificOutput was only consumed by PreGenerate hooks (for generation caching). Now PreToolUse hooks can return respondWith to short-circuit tool execution and return a synthetic result without calling the original tool's execute function.
  - When a PreToolUse hook provides respondWith, PostToolUse hooks still fire with the synthetic result as tool_response, so observers (audit, logging, metrics) see the interception.
  - The evaluation order within PreToolUse is: permissionDecision (deny check) -> updatedInput (input transformation) -> respondWith (short-circuit). This means updatedInput is applied before respondWith is checked, and the modified input is passed to PostToolUse hooks.
  - No changes to the HookSpecificOutput interface -- respondWith was already defined on the type but not wired for tool hooks.

## Testing

  - bun run check
  - bun run type-check
  - bun run test (2153 passed, 8 skipped)

  Two new test cases added to tests/hooks.test.ts:
  - PreToolUse hook can short-circuit execution via respondWith -- verifies original tool execute is not called and the wrapped execute returns the respondWith value
  - PreToolUse respondWith still fires PostToolUse hooks -- verifies PostToolUse hooks receive the synthetic result with correct tool_name and tool_response

## Docs And Changelog

- [x] Updated CHANGELOG.md for public behaviour changes
- [x] Updated README/docs/examples where needed -- no README changes needed; respondWith is already documented on HookSpecificOutput and the behaviour now matches the type contract

## Breaking Changes

  - No breaking changes

## Notes

  - Required by the memory plugin's PreToolUse URI interception (LLE-9203) which resolves memory:// and wiki:// URIs via HTTP and returns the file content as a synthetic tool result
  - PostToolUseFailure hooks do not fire when respondWith is used -- the interception is treated as a successful result, not a failure
  - Reuses the existing extractRespondWith utility from hooks.ts (already exported and tested for PreGenerate use)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PreToolUse hooks can return synthetic tool results via respondWith to bypass actual tool execution; downstream PostToolUse hooks still run and can observe or modify the synthetic result.
  * Synthetic results are marked with a metadata flag so observability/audit hooks can distinguish intercepted calls.

* **Tests**
  * Added integration tests validating short‑circuiting, PostToolUse invocation with synthetic results, overriding behavior, input propagation and precedence rules.

* **Documentation**
  * CHANGELOG updated to describe the new hook behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->