### PR TITLE
Support typed multimodal sandbox read results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `PreToolUse` hooks now support `respondWith` in `HookSpecificOutput` to short-circuit tool execution and return a synthetic result without calling the original tool. `PostToolUse` hooks still fire with the synthetic result for observability, and the `PostToolUseInput` carries `tool_result_synthetic: true` so audit/log/metrics hooks can distinguish intercepted calls from real ones
+- `agent.stream()` now emits `turn-start` and `turn-end` lifecycle events bracketing each assistant message in the stream. `turn-end` carries the AI SDK response id (as `messageId`), the per-turn `finishReason`, and per-turn `usage`. This lets consumers attach a stable message identifier to deltas and tool calls without inventing one, and lets per-turn telemetry be recorded without awaiting the final result. The events are additive — exhaustive `switch` statements on `StreamPart` will see two new variants but no existing variant changes shape
+- Backend `read()` methods can now return typed `SandboxReadResult` values for text, image, file, rendered page, and unsupported reads. The default `read` tool projects supported images/files into AI SDK tool-result content and downgrades them to text fallbacks when `AgentOptions.modelCapabilities` declares the active model cannot accept those inputs
 
 ## [0.1.0-alpha.3] - 2026-04-23
 

--- a/docs/research/pi-agent-core-comparison.md
+++ b/docs/research/pi-agent-core-comparison.md
@@ -1,0 +1,320 @@
+# `pi-agent-core` study — implications for `@lleverage-ai/agent-sdk`
+
+**Status:** research note · prepared 2026-04-28 · scope: `@lleverage-ai/agent-sdk@0.1.0-alpha.3` vs `@mariozechner/pi-agent-core@0.70.6` (pi-mono).
+
+This document studies pi-agent-core as a reference implementation and proposes targeted changes to our SDK. It does **not** propose replacing the SDK or its dependencies. The accompanying PoC on `research/lifecycle-events` lands the smallest, most defensible item from the list (lifecycle events).
+
+---
+
+## 1. Executive summary
+
+pi-agent-core is a **2 000-LoC, single-purpose agent runtime** designed to be wrapped by a coding-agent CLI and a LitElement web UI. Our agent-sdk is a **~30-module enterprise framework** with checkpointing, MCP, plugin proxy, observability, security, and a public hook bus. They are not the same product and we should not try to make them the same product. They are both at a pre-1.0, alpha-cadence stage; pi-agent-core ships every 1–3 days and is a single-maintainer project.
+
+That said, pi-agent-core is **clearly better than us at three things**:
+
+1. **Event lifecycle.** It emits `agent_start/end`, `turn_start/end`, `message_start/update/end`, `tool_execution_start/update/end` as a uniform, additive discriminated union. Our `StreamPart` is an AI SDK pass-through with no turn or message boundaries — workflow-service hand-rolls a `messageId` and a `step-started/finished` mapping in `stream-event-mapper.ts` to compensate.
+2. **Live state observability.** Its `AgentState` exposes `isStreaming`, `streamingMessage`, `pendingToolCalls`, `errorMessage` as readonly accessors. UI components can `requestUpdate()` against them directly. Our `Agent` is opaque between `generate()` calls.
+3. **Mid-run user input (steering / follow-up).** It has a documented public API — `agent.steer(message)`, `agent.followUp(message)`, with explicit drain points and "one-at-a-time" / "all" modes. Our `AgentSession.sendMessage()` exists but is private to the session abstraction; its queue is not surfaced through `Agent` and not part of `Checkpoint`.
+
+It is **clearly worse than us** at: persistence (no built-in checkpointer), hook breadth (no `PreCheckpointSave`, no `PostCompact`, no MCP lifecycle), provider routing (no fallback model + retry pipeline), tool-loading proxy (no `search_tools`/`call_tool`), security policies (no `applySecurityPolicy`), context compaction (only `transformContext` callback, no scheduler), and stability (breaking minor releases roughly weekly).
+
+It is **the same as us, just structured differently** at: tool execution (both wrap `execute(args, options)` with hooks; ours has more), provider abstraction (both pass an opaque model object through; pi-agent-core has `streamFn` injection, we don't).
+
+The right move: **borrow the event/state/queueing patterns; do not borrow the runtime**. The PoC on this branch lands the smallest piece (lifecycle events).
+
+---
+
+## 2. Dimension-by-dimension comparison
+
+### 2.1 Agent state model
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Persistable snapshot | `Checkpoint { threadId, step, messages, state, pendingInterrupt?, createdAt, updatedAt, metadata? }` (`src/checkpointer/types.ts:143`) | None. Consumers serialise themselves; coding-agent uses a JSONL-with-versioned-entries format |
+| In-memory state | `AgentState { todos, files }` (`src/backends/state.ts:96`) — todo + virtual filesystem only | `AgentState { systemPrompt, model, thinkingLevel, tools, messages, isStreaming, streamingMessage, pendingToolCalls, errorMessage }` (`packages/agent/src/types.ts:264`) — full live view |
+| Storage backends | `MemorySaver`, `FileSaver`, `KeyValueStoreSaver`, plus `BaseCheckpointSaver` interface | Out of scope |
+| Resume | `agent.resume(threadId, interruptId, response)` reconstructs from storage | `Agent.continue()` uses in-memory state only |
+| Mutability | `Checkpoint` is plain JSON; `Agent` instance is immutable across `generate()` calls (closures only) | `agent.state.tools = [...]` works at runtime; getters/setters; mutation by design |
+
+**Where each model wins:**
+
+- pi-agent-core wins on **live observability**: a UI component can read `agent.state.isStreaming` and `agent.state.streamingMessage` to render a "currently typing…" indicator and the partial assistant message without subscribing to events. Our SDK forces consumers to track this themselves (workflow-service's `executeAgentStreamAttempt` does exactly that).
+- agent-sdk wins on **persistence**: workflow-service's GCS checkpoint saver is a 124-line implementation of `BaseCheckpointSaver` (`apps/workflow-service/src/modules/agent/platform/checkpointer/gcs-checkpoint-saver.ts`). pi-agent-core punts persistence entirely; coding-agent re-implements it from scratch in a 700-LoC `SessionManager`. For a multi-tenant platform, the SDK-owned checkpointer is a feature, not a flaw.
+- agent-sdk wins on **portability**: `Checkpoint` is JSON-serialisable and round-trips through GCS. pi-agent-core's state contains a `Model<TApi>` instance, which is not portable.
+
+**Conclusion:** keep our `Checkpoint` shape. Add a small **live state surface** on `Agent` so UIs can observe in-flight runs without hand-rolling.
+
+### 2.2 Event / stream model
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Event union | `StreamPart` — 11 variants, mostly AI SDK pass-through (`src/types.ts:2256`) | `AgentEvent` — 10 variants with explicit lifecycle (`packages/agent/src/types.ts:350`) |
+| Lifecycle | None — turn boundaries inferred from `step-start`/`step-finish` chunks **which our `stream()` silently drops** (`src/agent.ts:2944-2997`) | `agent_start`, `agent_end`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end` |
+| Tool events | `tool-call`, `tool-result` | `tool_execution_start`, `tool_execution_update` (partial results), `tool_execution_end` |
+| Stable IDs | None — `tool-call.toolCallId` and `tool-result.toolCallId` only; no message id | Per-message `id` and `assistantMessageEvent` correlate everything |
+| Delivery | `AsyncGenerator<StreamPart>` from `agent.stream()`; AI-SDK UI-message protocol from `streamResponse`; `UIMessageStreamWriter` from `streamDataResponse` | `EventStream<AgentEvent, AgentMessage[]>` from `agentLoop()`; subscribe callback from `Agent.subscribe()` |
+
+**The gap that bites us today:** workflow-service hand-rolls `assistantMessageId`, threads it through 17 emitter calls in `run-executor.ts`, then re-emits AI-SDK chunk types (`step-start`, `step-finish`, `tool-input-available`, `tool-output-available`, …) as `step-started`/`step-finished`/`tool-call`/`tool-result` in `stream-event-mapper.ts` (~250 LoC). The SDK already knows the canonical shape but doesn't expose it.
+
+pi-agent-core's `turn_start/turn_end` is the simplest fix and aligns 1:1 with AI SDK's `start-step`/`finish-step` chunks (which the SDK currently drops). **The PoC on this branch implements exactly that.** It's purely additive and unlocks workflow-service simplification.
+
+### 2.3 Interruption / queued input
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Tool-driven interrupt | `await options.interrupt(state, { type })` throws `InterruptSignal`; outer wrapper catches; `Checkpoint.pendingInterrupt` records it (`src/agent.ts:118, 429`) | None — pi-agent-core has no checkpointer-backed interrupts |
+| Approval interrupts | `canUseTool(name, input) → "allow" \| "deny" \| "ask"` produces `ApprovalInterrupt` | None |
+| Mid-turn user input | None at `Agent` level; `AgentSession.sendMessage()` queues between turns (private) | `agent.steer(msg)` and `agent.followUp(msg)` with documented drain points; "one-at-a-time" / "all" modes |
+| Cancellation | `AbortController` on `GenerateOptions.signal`; plumbed into AI SDK and tools | `agent.abort()` aborts an `AbortController`; `agent.signal` exposed |
+| Resume | `agent.resume(threadId, interruptId, response)` from checkpoint | `agent.continue()` from in-memory state |
+
+**Where each wins:**
+
+- agent-sdk wins on **interrupt fidelity** — a tool can request structured input, the agent suspends to a checkpoint, and the resume path can come hours later from a different process. workflow-service exploits this for OAuth dance, ask-user, workflow-node pauses, and integration-action callbacks.
+- pi-agent-core wins on **mid-run steering** — a user can inject a follow-up message while the model is still thinking, and the loop drains it at the next turn boundary. Our `AgentSession` does this but it's not exposed on `Agent` itself, and the queue is not part of `Checkpoint`.
+
+**Workflow-service compensates** by building a per-run interrupt gate (`interrupt-gate.ts`), a Redis+GCS double-write of interrupt data (`agent.service.ts:262-282`), and a 13-branch `prepareResume` switch (`agent.service.ts`) that re-executes the original tool, patches checkpoints, etc. Some of this complexity is intrinsic to multi-tenant interrupt semantics — but the steering case is genuinely missing.
+
+**Conclusion:** keep our interrupt machinery. Add a public `agent.steer(message)` that drains between turns. Make the queue part of `Checkpoint` so a steering message issued during a checkpointed pause survives a resume.
+
+### 2.4 Tool execution
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Tool definition | AI SDK `tool({ description, inputSchema, execute })` — re-export | `AgentTool { label, prepareArguments?, execute(toolCallId, args, signal, onUpdate?) }` extending pi-ai's `Tool` |
+| Validation | AI SDK does it via Zod | typebox `validateToolArguments` |
+| Lifecycle hooks | `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `ToolRegistered`, `ToolLoadError` plus tool-name regex matchers | `beforeToolCall`, `afterToolCall` |
+| Per-tool execution mode | None | `executionMode: "sequential" \| "parallel"` per tool; one sequential tool in a batch downgrades the whole batch |
+| Partial results | `StreamingContext.writer.write(...)` with `data-*` parts | `onUpdate(partial)` callback driving `tool_execution_update` events |
+| Cancellation | `AbortSignal` via `ToolExecutionOptions.abortSignal` | `AbortSignal` arg |
+| Termination | None — a tool can `throw InterruptSignal` to stop the loop | `AgentToolResult.terminate: true` short-circuits when **all** results in a batch terminate |
+
+**Where each wins:**
+
+- agent-sdk wins on **hook breadth** and **regex matchers** — `PreToolUse[matcher: "^bash$"]` is a real, tested pattern (`src/hooks.ts:62`).
+- pi-agent-core wins on **execution mode + onUpdate**. Workflow-service approximates `onUpdate` via `StreamingContext.writer.write({ type: "data-workflow-form" })` (`runtime/node-to-tool.ts:232-243`), but this is plumbed only through `streamDataResponse()`, not through `agent.stream()`. A typed `onUpdate` would be more uniform.
+
+**Conclusion:** keep our hook system. Consider adding a per-tool `executionMode` option (medium impact, additive). Defer `onUpdate` until we've seen more demand — the `StreamingContext.writer` pattern is fine for now.
+
+### 2.5 Transport / UI separation
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Core stream | `agent.stream() → AsyncGenerator<StreamPart>` | `agentLoop() → EventStream<AgentEvent>` |
+| Web Response | `agent.streamResponse() → Response` (UI-message protocol); `agent.streamDataResponse() → Response` (UI-message + custom data parts); `agent.streamRaw()` | None — consumers wrap themselves |
+| Sibling transport packages | `@lleverage-ai/agent-threads` (WebSocket runtime) | `streamProxy()` (single function in same package) |
+| UI-message protocol | First-class via AI SDK's `toUIMessageStreamResponse()` | None |
+
+pi-agent-core has cleaner separation but it's because it does less. Our `streamResponse`/`streamDataResponse` are real productivity wins for Next.js consumers and are not making workflow-service's life harder (workflow-service uses `agent.stream()`, not the Web Response variants). The cost of moving them to a sibling package is high; the benefit is mostly aesthetic.
+
+**Conclusion:** no action. Document the layering more clearly (which method to use when), but don't fragment the package.
+
+### 2.6 Provider abstraction
+
+| | `@lleverage-ai/agent-sdk` | `pi-agent-core` |
+|---|---|---|
+| Model interface | Vercel AI SDK `LanguageModel` passed through | pi-ai `Model<TApi>` passed through |
+| Wrapper | None — `streamText`/`generateText` from `ai` called directly in `agent.ts` | `streamFn: StreamFn` injection point on `Agent`/`AgentLoopConfig`; default is `streamSimple` |
+| Provider count | Whatever Vercel AI SDK supports (~25 first-party + community) | 25+ via pi-ai's `KnownProvider` union with per-API `compat` overrides |
+| Special features | `fallbackModel`, `generationRetryPolicy` (overload/auth/transport/context_overflow classifications) | First-class thinking blocks (`ThinkingContent` with `signature`), cost accounting in every `Usage`, cache retention preference, OAuth provider system, OpenRouter routing knobs |
+
+The user's brief was explicit: do not replace Vercel AI SDK. I agree. Vercel AI SDK v6 has thinking blocks, prompt caching, tool approval, and is the de-facto industry standard. The migration cost would be enormous (every provider, every test, every hook input shape) and the win is marginal.
+
+The one thing pi-agent-core has that we lack is **`streamFn` injection** — a single hook that lets you replace the model call. Use cases:
+- Test recordings without `vi.mock("ai", ...)` per file
+- Custom telemetry on the model call without wrapping every provider
+- Proxy through a managed gateway (already partially solved via `vercel-ai-gateway` provider)
+
+**Conclusion:** investigate exposing a `streamFn?: typeof streamText` option on `createAgent` as a thin escape hatch. This is a small additive change that helps recordings and proxy use cases without touching the runtime.
+
+---
+
+## 3. Ranked improvements
+
+Ranked by `(impact / migration cost)` for our SDK and our consumers (workflow-service, partners-app, agent-cli). All of these are additive; none are breaking.
+
+### 1. Lifecycle events: `turn-start` / `turn-end` (LANDED IN POC) — high impact, low cost
+
+**Problem:** workflow-service generates `assistantMessageId` itself and threads it through the stream. It also re-derives `step-started`/`step-finished` from chunks the SDK's `agent.stream()` silently drops.
+
+**Change:** add `turn-start { messageId? }` and `turn-end { messageId?, finishReason?, usage? }` to `StreamPart`. Emit them on AI SDK's `start-step` / `finish-step`. Bracket the cached-result path the same way.
+
+**Impact:**
+- Workflow-service can use the SDK's `messageId` instead of inventing one (~17 callsites in `run-executor.ts`).
+- Workflow-service can drop `step-start` / `step-finish` mapping (~10 lines in `stream-event-mapper.ts`).
+- Per-turn telemetry (one usage per turn) becomes available without awaiting the final result.
+
+**Migration:** zero — additive types, exhaustive switches see new variants but no existing variant changed shape.
+
+**Status:** implemented on `research/lifecycle-events`. Three new tests, full suite passes, type-check clean.
+
+### 2. Stable agent message IDs in mid-stream events — high impact, low cost
+
+**Problem:** the `text-delta`, `reasoning-delta`, and `tool-call` events have no message id, so consumers can't correlate them to the assistant message they belong to until `turn-end` fires.
+
+**Change:** annotate `text-delta`, `reasoning-delta`, `tool-call`, `tool-result` with an optional `messageId?: string` populated from the same `LanguageModelResponseMetadata` we surface on `turn-end`. (AI SDK doesn't carry the id on `start-step`, but it does carry it at the start of the assistant message via the `start` chunk for full UI-message-protocol streams; we'd populate `messageId` from the most recently seen `finish-step.response.id` after the first turn boundary, and leave it `undefined` for the first turn.)
+
+**Impact:** workflow-service drops its private `assistantMessageId` plumbing.
+
+**Migration:** zero — optional field on existing variants.
+
+**Trade-off:** the first-turn deltas have no id. Workflow-service can fall back to its own generation in that one window, or we can derive a synthetic id from `runId`.
+
+### 3. Public `agent.steer(message)` / `agent.followUp(message)` with checkpointed queue — high impact, medium cost
+
+**Problem:** `AgentSession.sendMessage()` exists but the queue is private and not in `Checkpoint`. workflow-service has no way to inject a mid-run user message.
+
+**Change:** add `steerQueue: ModelMessage[]` and `followUpQueue: ModelMessage[]` to `Checkpoint`. Add `agent.steer(msg)` / `agent.followUp(msg)` methods that push onto these queues and persist via the checkpointer. Drain `steerQueue` at the top of each step in `agent.stream()`; drain `followUpQueue` at loop exit. Mode: default `"one-at-a-time"`, configurable per call.
+
+**Impact:** unlocks live conversation steering for workflow runs. Replaces the private session queue.
+
+**Migration:** additive on `Checkpoint` (consumers ignore unknown keys). One-line on workflow-service to wire `POST /threads/:id/steer` to `agent.steer`.
+
+**Risk:** subtle race conditions between drain and AI SDK abort. pi-agent-core's reference implementation handles this by having drain points outside the AI SDK call. We'd want a similar pattern.
+
+### 4. Live state surface: `agent.getState(threadId)` — medium impact, low cost
+
+**Problem:** UIs and admin endpoints want "what is the agent currently doing for thread X" without subscribing to events. Today the answer requires loading the latest checkpoint and inspecting `pendingInterrupt`.
+
+**Change:** add `agent.getState(threadId): { isStreaming: boolean; pendingToolCalls: Set<string>; lastMessageId?: string; pendingInterrupt?: Interrupt }`. Driven by the existing `threadCheckpoints` map and a small in-memory run registry.
+
+**Impact:** workflow-service can drop its `Map<threadId, RunState>` (`runtime.ts:60-100`) parallel to `agent.taskManager`.
+
+**Migration:** additive.
+
+### 5. Re-export missing backend types — low impact, trivial cost
+
+**Problem:** `gvisor-sandbox-backend.ts:21-34` inlines `ExecuteBackgroundOptions`, `ExecuteBackgroundResult`, `SandboxCallOptions`, `WriteOptions`, `SandboxLogger` because the SDK only exports the read-side types.
+
+**Change:** add the missing exports to `src/index.ts`.
+
+**Impact:** workflow-service deletes ~20 LoC of duplicated types. Improves type-driver bug detection.
+
+**Migration:** zero — only adding exports.
+
+### 6. Per-tool `executionMode: "sequential" | "parallel"` — medium impact, medium cost
+
+**Problem:** ask-user, OAuth init, and skill-mutation tools have side effects that benefit from being sequenced. Today each tool wraps its own mutex or hopes the model serialises.
+
+**Change:** add `executionMode?: "sequential" | "parallel"` to tool definitions (or to a `tool.experimental_metadata` field). When the SDK calls a batch of tool-calls, if any has `executionMode: "sequential"`, run the whole batch sequentially (pi-agent-core's "downgrade" semantics).
+
+**Impact:** workflow-service drops a couple of ad-hoc mutexes. More predictable side-effect ordering.
+
+**Migration:** additive. Default behaviour (parallel) unchanged.
+
+**Trade-off:** AI SDK doesn't natively support per-tool sequencing. We'd implement it in our tool wrapper layer. Some performance loss for batches that contain even one sequential tool.
+
+### 7. `streamFn?: typeof streamText` injection point — medium impact, medium cost
+
+**Problem:** test recordings need `vi.mock("ai", ...)` per file. There's no clean way to swap in a managed-gateway proxy or a recording stream without forking.
+
+**Change:** add `streamFn?: typeof streamText` and `generateFn?: typeof generateText` options to `createAgent`. Default to the AI SDK functions. Use the override everywhere `streamText`/`generateText` is called (5 sites in `agent.ts`).
+
+**Impact:** simpler test setup. Enables a pluggable model proxy for org-level cost accounting and audit.
+
+**Migration:** additive.
+
+**Trade-off:** any per-call wrapper has to honour the AI SDK signature exactly — drift across AI SDK versions becomes a maintenance hazard.
+
+### 8. `interruptedAt?` flag on `ModelMessage` (or on `Checkpoint`) — medium impact, medium cost
+
+**Problem:** `interrupted-assistant-checkpointer.ts` adds and removes the literal string `"\n\n[This response was interrupted before completion.]"` to assistant messages on every load/save. It only exists because the SDK has no other way to mark an assistant message as cut short.
+
+**Change:** add `messageStatus?: "complete" | "interrupted"` (or `interruptedAt?: string`) to a per-message metadata sidecar in `Checkpoint` (avoid touching `ModelMessage` since that's an AI SDK type).
+
+**Impact:** workflow-service deletes the wrapper checkpointer.
+
+**Migration:** additive on `Checkpoint`. Wrapper-removal is local to workflow-service.
+
+### 9. SDK-issued interrupt IDs tied to tool calls — low impact, low cost
+
+**Problem:** workflow-service uses an `int_<toolCallId>` convention to correlate interrupts to tool calls. This is undocumented and fragile.
+
+**Change:** when `interrupt()` produces an `Interrupt`, set `Interrupt.toolCallId` and (optionally) make `Interrupt.id` derive from the tool call. Document the convention.
+
+**Impact:** workflow-service deletes `extractToolCallIdFromInterruptId`. Removes the magic prefix.
+
+**Migration:** additive type field; the magic prefix can stay until consumers migrate.
+
+### 10. Single-interrupt-per-turn policy — low impact, low cost
+
+**Problem:** `interrupt-gate.ts:50-89` exists because the SDK allows multiple tools in a turn to call `interrupt()` and only the first one surfaces predictably. workflow-service throws `ParallelInterruptError` to enforce its own invariant.
+
+**Change:** add `interruptPolicy?: "single-per-turn" | "first-wins"` (default `"first-wins"` — current behaviour). When `"single-per-turn"`, the SDK throws on the second concurrent interrupt.
+
+**Impact:** workflow-service drops the gate.
+
+**Migration:** opt-in flag.
+
+---
+
+## 4. Do not adopt
+
+Findings where pi-agent-core's pattern is **not** appropriate for us.
+
+### A. Do not replace Vercel AI SDK with pi-ai
+
+pi-ai has nice features (thinking blocks with signatures, cost accounting, OAuth providers, OpenRouter routing). Most of these are now in Vercel AI SDK v6 (thinking, caching, tool approval). The migration cost — every provider, every hook input shape, every test mock — would be measured in person-months. The win is marginal. Stay on Vercel AI SDK.
+
+### B. Do not adopt the class-with-mutable-state pattern
+
+pi-agent-core's `agent.state.tools = [...]`, `agent.beforeToolCall = fn` is convenient for a single-process CLI/UI but disastrous for our multi-tenant service. Mutation by assignment is invisible to telemetry, breaks observability, and in workflow-service would create cross-thread contamination. Keep `createAgent(options)` as the immutable factory.
+
+### C. Do not abandon the SDK-owned checkpointer
+
+pi-agent-core's "no checkpointer" stance forces every consumer to roll their own persistence (coding-agent has 700 LoC of `SessionManager`; partners-app, agent-cli, workflow-service would each duplicate). Our `BaseCheckpointSaver` interface is the right abstraction for a platform; keep it.
+
+### D. Do not adopt `CustomAgentMessages` declaration merging
+
+It's clever but global side effects through TypeScript declaration merging are fragile in monorepos with multiple consumers (workflow-service, partners-app, app, agent-cli all import the SDK and would race on the merge). Tree-shaking suffers. Our `data-*` UI parts pattern in `streamDataResponse` is fine.
+
+### E. Do not adopt pi-agent-core's release cadence
+
+Mario ships ~14 versions a month, often with breaking changes. Lleverage agent-sdk has external consumers (workflow-service, agent-cli, partners-app, customers using `@lleverage-ai/agent-threads`); we need stable APIs. Continue with planned semver discipline. Keep alpha changes inside `0.1.0-alpha.x`; bundle breaking changes into a single `0.2.0` release rather than dripping them.
+
+### F. Do not move `streamResponse`/`streamDataResponse` to a sibling package
+
+The cleaner separation pi-agent-core has is partly because its UI is a separate package. For us, `streamResponse` (Next.js useChat) is a primary feature; fragmenting the package adds dependency complexity for partners. Keep them in the main package and document the layering.
+
+### G. Do not adopt per-tool `prepareArguments` shim
+
+pi-agent-core uses it to coerce LLM args before validation. We already get coercion from Zod. Adding a second hook layer would duplicate work and create ambiguity about where validation happens.
+
+### H. Do not adopt the in-package `streamProxy` HTTP proxy
+
+It's coupled to pi-agent-core's particular `ProxySerializableStreamOptions` shape. We have `@lleverage-ai/agent-threads` for transport. Keep that separation.
+
+---
+
+## 5. Compatibility checklist
+
+Anything proposed above must preserve workflow-service's existing surface. Concretely:
+
+- ✓ `agent.stream({ messages, threadId, … })` keeps returning `AsyncIterable<StreamPart>`. New event types are additive.
+- ✓ `Checkpoint.messages` keeps the AI SDK `ModelMessage[]` shape and round-trips through GCS.
+- ✓ `BaseCheckpointSaver { save, load, list, delete, exists }` interface unchanged.
+- ✓ `ExtendedToolExecutionOptions { interrupt, toolCallId, taskManager? }` unchanged.
+- ✓ `definePlugin({ name, description, deferred?, tools, skills?, … })` unchanged.
+- ✓ `pluginLoading: "proxy"` semantics unchanged.
+- ✓ `createContextManager(...)` accepts all current options.
+- ✓ `createDefaultPromptBuilder(components)` API unchanged.
+- ✓ `agent.taskManager` and `agent.getInterrupt(threadId)` still present.
+- ✓ Hook event names and shapes unchanged. New events would be additional registrations, not replacements.
+
+The PoC on this branch satisfies all of the above.
+
+---
+
+## 6. PoC summary (this branch)
+
+**Branch:** `research/lifecycle-events`
+
+**Files changed:**
+- `packages/agent-sdk/src/types.ts` — add `turn-start` and `turn-end` to `StreamPart` union (additive).
+- `packages/agent-sdk/src/agent.ts` — emit `turn-start` on AI SDK `start-step`; emit `turn-end` on `finish-step` with `messageId` from `response.id`, plus per-turn `finishReason` and `usage`. Bracket the cached-result short-circuit the same way.
+- `packages/agent-sdk/tests/streaming-lifecycle-events.test.ts` — three new tests covering single-turn, multi-turn (with tool round-trip), and missing-response-id paths.
+- `CHANGELOG.md` — entry under `[Unreleased]`.
+
+**Test results:** 2159/2167 pass (8 pre-existing skips), type-check clean.
+
+**Follow-up the PoC enables in workflow-service:** see ranked items 1, 2 — they become a small mechanical patch (drop `assistantMessageId` plumbing in `run-executor.ts`; drop the `step-start`/`step-finish` cases in `stream-event-mapper.ts`).

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -92,6 +92,7 @@ import type {
   InterruptResolvedInput,
   MCPConnectionFailedInput,
   MCPConnectionRestoredInput,
+  ModelInputCapabilities,
   PermissionDecision,
   PermissionMode,
   PostGenerateInput,
@@ -106,6 +107,40 @@ import type {
 } from "./types.js";
 
 let agentIdCounter = 0;
+
+type ToolContentOutputPart =
+  | { type: "text"; text: string; [key: string]: unknown }
+  | { type: "media"; data: string; mediaType: string; [key: string]: unknown }
+  | { type: "image-data"; data: string; mediaType: string; [key: string]: unknown }
+  | { type: "image-url"; url: string; [key: string]: unknown }
+  | { type: "image-file-id"; fileId: string | Record<string, string>; [key: string]: unknown }
+  | {
+      type: "file-data";
+      data: string;
+      mediaType: string;
+      filename?: string;
+      [key: string]: unknown;
+    }
+  | { type: "file-url"; url: string; [key: string]: unknown }
+  | { type: "file-id"; fileId: string | Record<string, string>; [key: string]: unknown }
+  | { type: "custom"; [key: string]: unknown }
+  | { type: string; [key: string]: unknown };
+
+type ToolContentOutput = {
+  type: "content";
+  value: ToolContentOutputPart[];
+  [key: string]: unknown;
+};
+
+/** @internal */
+function isToolContentOutput(output: unknown): output is ToolContentOutput {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "content" &&
+    Array.isArray((output as { value?: unknown }).value)
+  );
+}
 
 /**
  * Internal signal for interrupt flow control.
@@ -144,6 +179,167 @@ function withCheckpointRunId(
       ...(runId ? { runId } : {}),
     },
   });
+}
+
+/** @internal */
+function resolveModelInputCapabilities(
+  options: AgentOptions,
+  model: AgentOptions["model"],
+): ModelInputCapabilities | undefined {
+  const resolver = options.modelCapabilities;
+
+  if (!resolver) {
+    return undefined;
+  }
+
+  return typeof resolver === "function" ? resolver(model) : resolver;
+}
+
+/** @internal */
+function createToolExecutionContext(
+  options: AgentOptions,
+  model: AgentOptions["model"],
+): {
+  agentSdk: { currentModel: AgentOptions["model"]; modelCapabilities?: ModelInputCapabilities };
+} {
+  const modelCapabilities = resolveModelInputCapabilities(options, model);
+
+  return {
+    agentSdk: {
+      currentModel: model,
+      ...(modelCapabilities ? { modelCapabilities } : {}),
+    },
+  };
+}
+
+/** @internal */
+async function createToolModelOutput({
+  tool,
+  toolCallId,
+  input,
+  output,
+}: {
+  tool: Tool | undefined;
+  toolCallId: string;
+  input: unknown;
+  output: unknown;
+}): Promise<unknown> {
+  const toolWithModelOutput = tool as
+    | {
+        toModelOutput?: (options: {
+          toolCallId: string;
+          input: unknown;
+          output: unknown;
+        }) => unknown | PromiseLike<unknown>;
+      }
+    | undefined;
+
+  if (toolWithModelOutput?.toModelOutput) {
+    return toolWithModelOutput.toModelOutput({ toolCallId, input, output });
+  }
+
+  return typeof output === "string"
+    ? { type: "text" as const, value: output }
+    : { type: "json" as const, value: output ?? null };
+}
+
+/** @internal */
+function downgradeToolContentOutput(
+  output: unknown,
+  capabilities: ModelInputCapabilities | undefined,
+): unknown {
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "json" &&
+    "value" in output
+  ) {
+    return {
+      ...output,
+      value: downgradeToolContentOutput((output as { value: unknown }).value, capabilities),
+    };
+  }
+
+  if (!isToolContentOutput(output)) {
+    return output;
+  }
+
+  const value: ToolContentOutputPart[] = [];
+
+  for (const part of output.value) {
+    switch (part.type) {
+      case "text":
+        value.push(part);
+        break;
+      case "image-data":
+      case "image-url":
+      case "image-file-id":
+      case "media":
+        value.push(
+          capabilities?.imageInput === false
+            ? {
+                type: "text",
+                text: "[Image omitted: active model does not support image input.]",
+              }
+            : part,
+        );
+        break;
+      case "file-data":
+      case "file-url":
+      case "file-id":
+        value.push(
+          capabilities?.fileInput === false
+            ? {
+                type: "text",
+                text: "[File omitted: active model does not support file input.]",
+              }
+            : part,
+        );
+        break;
+      case "custom":
+        value.push(part);
+        break;
+      default:
+        value.push(part);
+        break;
+    }
+  }
+
+  return { ...output, value };
+}
+
+/** @internal */
+function projectMessagesForModel(
+  messages: ModelMessage[],
+  capabilities: ModelInputCapabilities | undefined,
+): ModelMessage[] {
+  if (capabilities?.imageInput !== false && capabilities?.fileInput !== false) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (message.role !== "tool" || !Array.isArray(message.content)) {
+      return message;
+    }
+
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type !== "tool-result") {
+          return part;
+        }
+
+        const output = "output" in part ? part.output : undefined;
+        const result = "result" in part ? (part as { result?: unknown }).result : undefined;
+
+        return {
+          ...part,
+          ...("output" in part ? { output: downgradeToolContentOutput(output, capabilities) } : {}),
+          ...("result" in part ? { result: downgradeToolContentOutput(result, capabilities) } : {}),
+        };
+      }),
+    };
+  }) as ModelMessage[];
 }
 
 /**
@@ -2084,10 +2280,12 @@ export function createAgent(options: AgentOptions): Agent {
         }
 
         try {
+          const toolExecutionContext = createToolExecutionContext(options, options.model);
           toolResultOutput = await tool.execute(interrupt.request.args, {
             toolCallId: interrupt.toolCallId,
             messages: checkpoint.messages,
             abortSignal: genOptions?.signal,
+            experimental_context: toolExecutionContext,
             executionTelemetry: resumeTelemetry,
           } as ToolExecutionOptions);
         } catch (error) {
@@ -2100,13 +2298,12 @@ export function createAgent(options: AgentOptions): Agent {
         }`;
       }
 
-      // Build the tool result message with proper ToolResultOutput format.
-      // The AI SDK validates messages against modelMessageSchema which
-      // requires output to be { type: 'text', value } or { type: 'json', value }.
-      const approvalOutput =
-        typeof toolResultOutput === "string"
-          ? { type: "text" as const, value: toolResultOutput }
-          : { type: "json" as const, value: toolResultOutput };
+      const approvalOutput = await createToolModelOutput({
+        tool: approvalResponse.approved ? collectAllTools()[interrupt.toolName] : undefined,
+        toolCallId: interrupt.toolCallId,
+        input: interrupt.request.args,
+        output: toolResultOutput,
+      });
 
       const toolResultMessage = {
         role: "tool" as const,
@@ -2185,6 +2382,7 @@ export function createAgent(options: AgentOptions): Agent {
 
     let customToolResult: unknown;
     try {
+      const toolExecutionContext = createToolExecutionContext(options, options.model);
       // Execute the tool, providing an interrupt function that returns
       // the stored user response. This mirrors what happens inside the
       // permission-mode tool wrapper when pendingResponses has a match.
@@ -2192,6 +2390,7 @@ export function createAgent(options: AgentOptions): Agent {
         toolCallId: customToolCallId,
         messages: checkpoint.messages,
         abortSignal: genOptions?.signal,
+        experimental_context: toolExecutionContext,
         executionTelemetry: resumeTelemetry,
         interrupt: async (request: unknown) => {
           // First call: return the stored user response (mirrors the
@@ -2237,11 +2436,12 @@ export function createAgent(options: AgentOptions): Agent {
       customToolResult = `Tool execution failed: ${executeError instanceof Error ? executeError.message : String(executeError)}`;
     }
 
-    // Build tool result message with proper ToolResultOutput format.
-    const customOutput =
-      typeof customToolResult === "string"
-        ? { type: "text" as const, value: customToolResult }
-        : { type: "json" as const, value: customToolResult };
+    const customOutput = await createToolModelOutput({
+      tool: customTool,
+      toolCallId: customToolCallId,
+      input: interrupt.request,
+      output: customToolResult,
+    });
 
     const customToolResultMessage = {
       role: "tool" as const,
@@ -2385,12 +2585,16 @@ export function createAgent(options: AgentOptions): Agent {
           const signalStopCondition = () => signalState.interrupt != null;
 
           const generationStartTime = Date.now();
+          const toolExecutionContext = createToolExecutionContext(options, retryState.currentModel);
 
           // Execute generation
           const response = await generateText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: initialParams.messages,
+            messages: projectMessagesForModel(
+              initialParams.messages,
+              toolExecutionContext.agentSdk.modelCapabilities,
+            ),
             tools: initialParams.tools as ToolSet,
             maxOutputTokens: initialParams.maxTokens,
             temperature: initialParams.temperature,
@@ -2402,6 +2606,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_context: toolExecutionContext,
           });
 
           // Check for intercepted interrupt signal (cooperative path)
@@ -2829,13 +3034,28 @@ export function createAgent(options: AgentOptions): Agent {
         );
         // Only process complete results (interrupted results can't be cached)
         if (cachedResult.status === "complete") {
-          // Yield cached result as stream parts
-          // First, yield text as a single text-delta
-          if (cachedResult.text) {
-            yield { type: "text-delta", text: cachedResult.text };
+          const cachedSteps = cachedResult.steps ?? [];
+
+          if (cachedSteps.length === 0) {
+            yield { type: "turn-start" };
+            if (cachedResult.text) {
+              yield { type: "text-delta", text: cachedResult.text };
+            }
+            yield {
+              type: "turn-end",
+              finishReason: cachedResult.finishReason,
+              usage: cachedResult.usage,
+            };
           }
-          // Yield tool calls and results from steps
-          for (const step of cachedResult.steps ?? []) {
+
+          for (const [index, step] of cachedSteps.entries()) {
+            yield { type: "turn-start" };
+
+            const stepText = (index === 0 ? cachedResult.text : undefined) || step.text;
+            if (stepText) {
+              yield { type: "text-delta", text: stepText };
+            }
+
             for (const toolCall of step.toolCalls ?? []) {
               yield {
                 type: "tool-call",
@@ -2852,8 +3072,15 @@ export function createAgent(options: AgentOptions): Agent {
                 output: toolResult.output,
               };
             }
+
+            yield {
+              type: "turn-end",
+              finishReason: step.finishReason,
+              usage: step.usage,
+            };
           }
-          // Finally yield finish
+
+          // Finally yield finish (overall stream terminator)
           yield {
             type: "finish",
             finishReason: cachedResult.finishReason,
@@ -2922,12 +3149,16 @@ export function createAgent(options: AgentOptions): Agent {
           const signalStopCondition = () => signalState.interrupt != null;
           const generationStartTime = Date.now();
           let firstTextDeltaAt: number | undefined;
+          const toolExecutionContext = createToolExecutionContext(options, retryState.currentModel);
 
           // Execute stream
           const response = streamText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: initialParams.messages,
+            messages: projectMessagesForModel(
+              initialParams.messages,
+              toolExecutionContext.agentSdk.modelCapabilities,
+            ),
             tools: initialParams.tools as ToolSet,
             maxOutputTokens: initialParams.maxTokens,
             temperature: initialParams.temperature,
@@ -2939,10 +3170,34 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_context: toolExecutionContext,
           });
 
+          // AI SDK only carries the response id on `finish-step`, not on
+          // `start-step`, so `turn-start` is emitted without a messageId and
+          // consumers correlate via the matching `turn-end`.
           for await (const part of response.fullStream) {
-            if (part.type === "text-delta") {
+            if (part.type === "start-step") {
+              // A new assistant message is beginning.
+              yield { type: "turn-start" };
+            } else if (part.type === "finish-step") {
+              // The current assistant turn completed. Surface the response id
+              // (from AI SDK's LanguageModelResponseMetadata) plus per-turn
+              // finish reason and usage so consumers can record per-turn
+              // telemetry without polling the awaited promises.
+              const stepResponse = part.response as { id?: unknown } | undefined;
+              const messageId = typeof stepResponse?.id === "string" ? stepResponse.id : undefined;
+              yield {
+                type: "turn-end",
+                messageId,
+                finishReason: part.finishReason as StreamPart extends {
+                  type: "finish";
+                }
+                  ? StreamPart["finishReason"]
+                  : never,
+                usage: part.usage,
+              };
+            } else if (part.type === "text-delta") {
               firstTextDeltaAt ??= Date.now();
               yield { type: "text-delta", text: part.text };
             } else if (part.type === "reasoning-start") {
@@ -3289,6 +3544,7 @@ export function createAgent(options: AgentOptions): Agent {
 
           // Capture currentModel for use in the callback closure
           const modelToUse = retryState.currentModel;
+          const toolExecutionContext = createToolExecutionContext(options, modelToUse);
 
           // Stop condition: stop when an interrupt signal was caught, OR when
           // the step count reaches maxSteps.
@@ -3305,7 +3561,10 @@ export function createAgent(options: AgentOptions): Agent {
           const result = streamText({
             model: modelToUse,
             system: initialParams.system,
-            messages: initialParams.messages,
+            messages: projectMessagesForModel(
+              initialParams.messages,
+              toolExecutionContext.agentSdk.modelCapabilities,
+            ),
             tools: initialParams.tools as ToolSet,
             maxOutputTokens: initialParams.maxTokens,
             temperature: initialParams.temperature,
@@ -3317,6 +3576,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_context: toolExecutionContext,
             // Incremental checkpointing: save after each step if enabled
             onStepFinish: effectiveGenOptions.checkpointAfterToolCall
               ? async (stepResult) => {
@@ -3462,11 +3722,18 @@ export function createAgent(options: AgentOptions): Agent {
                         followUpMessages,
                         requestOptions.threadId,
                       );
+                      const toolExecutionContext = createToolExecutionContext(
+                        options,
+                        currentModel,
+                      );
 
                       return streamText({
                         model: currentModel,
                         system: getSystemPrompt(followUpPromptContext),
-                        messages: followUpMessages,
+                        messages: projectMessagesForModel(
+                          followUpMessages,
+                          toolExecutionContext.agentSdk.modelCapabilities,
+                        ),
                         tools: activeFollowUpTools as ToolSet,
                         maxOutputTokens: requestOptions.maxTokens,
                         temperature: requestOptions.temperature,
@@ -3477,6 +3744,7 @@ export function createAgent(options: AgentOptions): Agent {
                         // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                         providerOptions: requestOptions.providerOptions as any,
                         headers: requestOptions.headers,
+                        experimental_context: toolExecutionContext,
                       });
                     },
                   );
@@ -3698,12 +3966,16 @@ export function createAgent(options: AgentOptions): Agent {
           // the step count reaches maxSteps.
           const signalStopCondition = () => signalState.interrupt != null;
           const generationStartTime = Date.now();
+          const toolExecutionContext = createToolExecutionContext(options, retryState.currentModel);
 
           // Execute stream
           const result = streamText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: initialParams.messages,
+            messages: projectMessagesForModel(
+              initialParams.messages,
+              toolExecutionContext.agentSdk.modelCapabilities,
+            ),
             tools: initialParams.tools as ToolSet,
             maxOutputTokens: initialParams.maxTokens,
             temperature: initialParams.temperature,
@@ -3715,6 +3987,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_context: toolExecutionContext,
             // Incremental checkpointing: save after each step if enabled
             onStepFinish: effectiveGenOptions.checkpointAfterToolCall
               ? async (stepResult) => {
@@ -3969,12 +4242,16 @@ export function createAgent(options: AgentOptions): Agent {
               // the step count reaches maxSteps.
               const signalStopCondition = () => signalState.interrupt != null;
               const generationStartTime = Date.now();
+              const toolExecutionContext = createToolExecutionContext(options, modelToUse);
 
               // Execute stream
               const result = streamText({
                 model: modelToUse,
                 system: initialParams.system,
-                messages: initialParams.messages,
+                messages: projectMessagesForModel(
+                  initialParams.messages,
+                  toolExecutionContext.agentSdk.modelCapabilities,
+                ),
                 tools: initialParams.tools as ToolSet,
                 maxOutputTokens: initialParams.maxTokens,
                 temperature: initialParams.temperature,
@@ -3986,6 +4263,7 @@ export function createAgent(options: AgentOptions): Agent {
                 // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                 providerOptions: initialParams.providerOptions as any,
                 headers: initialParams.headers,
+                experimental_context: toolExecutionContext,
                 // Incremental checkpointing: save after each step if enabled
                 onStepFinish: effectiveGenOptions.checkpointAfterToolCall
                   ? async (stepResult) => {
@@ -4170,11 +4448,18 @@ export function createAgent(options: AgentOptions): Agent {
                         followUpMessages,
                         requestOptions.threadId,
                       );
+                      const toolExecutionContext = createToolExecutionContext(
+                        options,
+                        currentModel,
+                      );
 
                       return streamText({
                         model: currentModel,
                         system: getSystemPrompt(followUpPromptContext),
-                        messages: followUpMessages,
+                        messages: projectMessagesForModel(
+                          followUpMessages,
+                          toolExecutionContext.agentSdk.modelCapabilities,
+                        ),
                         tools: activeFollowUpTools as ToolSet,
                         maxOutputTokens: requestOptions.maxTokens,
                         temperature: requestOptions.temperature,
@@ -4185,6 +4470,7 @@ export function createAgent(options: AgentOptions): Agent {
                         // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                         providerOptions: requestOptions.providerOptions as any,
                         headers: requestOptions.headers,
+                        experimental_context: toolExecutionContext,
                       });
                     },
                   );

--- a/packages/agent-sdk/src/backend.ts
+++ b/packages/agent-sdk/src/backend.ts
@@ -57,6 +57,142 @@ export interface FileData {
   modified_at: string;
 }
 
+/**
+ * Text content returned from a backend read.
+ *
+ * This is equivalent to the historical string read result, but lets backends
+ * attach metadata while still preserving offset/limit text semantics.
+ *
+ * @category Backend
+ */
+export interface SandboxTextReadResult {
+  /** Discriminator for formatted text read results. */
+  type: "text";
+
+  /** Text content, usually formatted with line numbers and offset/limit applied. */
+  text: string;
+
+  /** Optional backend-defined metadata about the read operation. */
+  metadata?: unknown;
+}
+
+/**
+ * Image content returned from a backend read.
+ *
+ * `data` must be base64-encoded image data. The SDK read tool can project this
+ * into AI SDK tool-result content for models that support image inputs, or into
+ * a text fallback for models that do not.
+ *
+ * @category Backend
+ */
+export interface SandboxImageReadResult {
+  /** Discriminator for image read results. */
+  type: "image";
+
+  /** Optional text note to send alongside the image. */
+  text?: string;
+
+  /** Base64-encoded image bytes. */
+  data: string;
+
+  /** IANA media type for the image, such as `image/png`. */
+  mediaType: string;
+
+  /** Optional backend-defined metadata about the image. */
+  metadata?: unknown;
+}
+
+/**
+ * Generic file content returned from a backend read.
+ *
+ * `data`, when present, must be base64-encoded file data. This shape leaves room
+ * for native document/PDF reads while still allowing text-only fallbacks.
+ *
+ * @category Backend
+ */
+export interface SandboxFileReadResult {
+  /** Discriminator for native file/document read results. */
+  type: "file";
+
+  /** Optional text note or extracted summary to send alongside the file. */
+  text?: string;
+
+  /** Optional base64-encoded file bytes. */
+  data?: string;
+
+  /** IANA media type for the file, such as `application/pdf`. */
+  mediaType: string;
+
+  /** Optional filename hint for model/provider file parts. */
+  filename?: string;
+
+  /** Optional backend-defined metadata about the file. */
+  metadata?: unknown;
+}
+
+/**
+ * Rendered page images returned from a backend read.
+ *
+ * This is intended for PDFs and other paged documents where a backend renders
+ * selected pages into image data instead of returning a whole native document.
+ *
+ * @category Backend
+ */
+export interface SandboxRenderedPagesReadResult {
+  /** Discriminator for rendered page image read results. */
+  type: "rendered_pages";
+
+  /** Optional text note or extracted summary to send before the rendered pages. */
+  text?: string;
+
+  /** Rendered document pages, ordered as they should be shown to the model. */
+  pages: Array<{
+    /** One-based page number from the source document. */
+    page: number;
+
+    /** Base64-encoded rendered page image bytes. */
+    data: string;
+
+    /** IANA media type for the rendered page image, such as `image/png`. */
+    mediaType: string;
+  }>;
+
+  /** Optional backend-defined metadata about the rendered document. */
+  metadata?: unknown;
+}
+
+/**
+ * Unsupported content returned from a backend read.
+ *
+ * Backends can use this when they recognize a file but cannot provide text or
+ * typed content for it.
+ *
+ * @category Backend
+ */
+export interface SandboxUnsupportedReadResult {
+  /** Discriminator for unsupported read results. */
+  type: "unsupported";
+
+  /** Human-readable explanation of why the file could not be read usefully. */
+  text: string;
+}
+
+/**
+ * Provider-neutral content that can be returned by backend `read()` methods.
+ *
+ * String read results remain supported. Typed results let backend read tools
+ * expose images, native files, and rendered pages without flattening everything
+ * to plain text before the model sees it.
+ *
+ * @category Backend
+ */
+export type SandboxReadResult =
+  | SandboxTextReadResult
+  | SandboxImageReadResult
+  | SandboxFileReadResult
+  | SandboxRenderedPagesReadResult
+  | SandboxUnsupportedReadResult;
+
 // =============================================================================
 // Search Types
 // =============================================================================
@@ -179,26 +315,39 @@ export interface BackendProtocol {
   lsInfo(path: string): FileInfo[] | Promise<FileInfo[]>;
 
   /**
-   * Read file content with optional line numbers.
+   * Read file content with optional line range controls.
    *
-   * Returns content formatted with line numbers for display, suitable for
-   * showing to the model or user.
+   * Text-oriented backends may return a formatted string with line numbers,
+   * preserving the historical read contract. Multimodal backends may instead
+   * return a {@link SandboxReadResult} variant: `text` for formatted text with
+   * metadata, `image` for base64 image bytes plus media type, `file` for native
+   * document/file bytes, `rendered_pages` for page images, or `unsupported` for
+   * a clear text fallback.
+   *
+   * Callers must handle both synchronous and Promise returns, and must
+   * discriminate non-string results by `result.type`.
    *
    * @param filePath - Path to the file to read
    * @param offset - Starting line offset (0-indexed)
    * @param limit - Maximum number of lines to read
-   * @returns Formatted content with line numbers
+   * @returns Formatted text or a structured {@link SandboxReadResult}
    *
    * @example
    * ```typescript
-   * // Read first 50 lines
-   * const content = await backend.read("/src/index.ts", 0, 50);
+   * const result = await backend.read("/src/index.ts", 0, 50);
    *
-   * // Read lines 100-200
-   * const content = await backend.read("/src/index.ts", 100, 100);
+   * if (typeof result === "string") {
+   *   console.log(result);
+   * } else if (result.type === "image") {
+   *   console.log(result.mediaType, result.data);
+   * }
    * ```
    */
-  read(filePath: string, offset?: number, limit?: number): string | Promise<string>;
+  read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): string | SandboxReadResult | Promise<string | SandboxReadResult>;
 
   /**
    * Read raw file content as FileData.

--- a/packages/agent-sdk/src/backends/composite.ts
+++ b/packages/agent-sdk/src/backends/composite.ts
@@ -37,6 +37,7 @@ import type {
   FileData,
   FileInfo,
   GrepMatch,
+  SandboxReadResult,
   WriteResult,
 } from "../backend.js";
 
@@ -162,14 +163,22 @@ export class CompositeBackend implements BackendProtocol {
   }
 
   /**
-   * Read file content with optional line numbers.
+   * Read file content from the backend selected by path prefix.
+   *
+   * The routed backend may return historical formatted text, or a typed
+   * {@link SandboxReadResult} for multimodal reads such as images, native files,
+   * rendered pages, or unsupported content.
    *
    * @param filePath - Path to the file to read
    * @param offset - Starting line offset (0-indexed)
    * @param limit - Maximum number of lines to read
-   * @returns Formatted content with line numbers
+   * @returns Formatted text, or the routed backend's structured {@link SandboxReadResult}
    */
-  async read(filePath: string, offset?: number, limit?: number): Promise<string> {
+  async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<string | SandboxReadResult> {
     const { backend, relativePath } = this.resolveBackend(filePath);
     return backend.read(relativePath, offset, limit);
   }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -73,6 +73,12 @@ export type {
   FileInfo,
   FileUploadResponse,
   GrepMatch,
+  SandboxFileReadResult,
+  SandboxImageReadResult,
+  SandboxReadResult,
+  SandboxRenderedPagesReadResult,
+  SandboxTextReadResult,
+  SandboxUnsupportedReadResult,
   WriteResult,
 } from "./backend.js";
 // Backend
@@ -718,6 +724,9 @@ export type {
   LanguageModelUsage,
   MCPConnectionFailedInput,
   MCPConnectionRestoredInput,
+  ModelInputCapabilities,
+  ModelInputCapabilitiesResolver,
+  ModelInputCapabilitiesResolverFn,
   // MCP types
   MCPServerConfig,
   // AI SDK re-exports

--- a/packages/agent-sdk/src/tools/filesystem.ts
+++ b/packages/agent-sdk/src/tools/filesystem.ts
@@ -8,9 +8,11 @@
  * @packageDocumentation
  */
 
+import type { ToolExecutionOptions } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
-import type { BackendProtocol, FileInfo, GrepMatch } from "../backend.js";
+import type { BackendProtocol, FileInfo, GrepMatch, SandboxReadResult } from "../backend.js";
+import type { ModelInputCapabilities } from "../types.js";
 
 // =============================================================================
 // Constants
@@ -21,6 +23,185 @@ const DEFAULT_READ_LIMIT = 2000;
 
 /** Character count threshold for warning (approximate tokens = chars / 4) */
 const LARGE_CONTENT_WARNING_CHARS = 80_000; // ~20k tokens
+
+type ReadToolContentPart =
+  | { type: "text"; text: string }
+  | { type: "image-data"; data: string; mediaType: string }
+  | { type: "file-data"; data: string; mediaType: string; filename?: string };
+
+type ReadToolContentOutput = {
+  type: "content";
+  value: ReadToolContentPart[];
+};
+
+type ReadToolModelOutput =
+  | { type: "text"; value: string }
+  // biome-ignore lint/suspicious/noExplicitAny: Mirrors AI SDK JSON fallback typing.
+  | { type: "json"; value: any }
+  | ReadToolContentOutput;
+
+interface ReadToolExecutionContext {
+  agentSdk?: {
+    modelCapabilities?: ModelInputCapabilities;
+  };
+  modelCapabilities?: ModelInputCapabilities;
+}
+
+function isSandboxReadResult(value: unknown): value is SandboxReadResult {
+  const type = (value as { type?: unknown } | null)?.type;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (type === "text" ||
+      type === "image" ||
+      type === "file" ||
+      type === "rendered_pages" ||
+      type === "unsupported")
+  );
+}
+
+function getModelCapabilities(options?: ToolExecutionOptions): ModelInputCapabilities | undefined {
+  const context = options?.experimental_context as ReadToolExecutionContext | undefined;
+  return context?.agentSdk?.modelCapabilities ?? context?.modelCapabilities;
+}
+
+function supportsImageInput(options?: ToolExecutionOptions): boolean {
+  return getModelCapabilities(options)?.imageInput !== false;
+}
+
+function supportsFileInput(options?: ToolExecutionOptions): boolean {
+  return getModelCapabilities(options)?.fileInput !== false;
+}
+
+function withLargeContentWarning(text: string): string {
+  if (text.length <= LARGE_CONTENT_WARNING_CHARS) {
+    return text;
+  }
+
+  const estimatedTokens = Math.round(text.length / 4);
+  return `[Warning: Large file content (~${estimatedTokens} tokens). Consider using offset/limit to read specific sections.]\n\n${text}`;
+}
+
+function textPart(text: string): ReadToolContentPart {
+  return { type: "text", text };
+}
+
+function fallbackText(message: string, text?: string): string {
+  return withLargeContentWarning(text ? `${message}\n\n${text}` : message);
+}
+
+function isReadToolContentOutput(value: unknown): value is ReadToolContentOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "content" &&
+    Array.isArray((value as { value?: unknown }).value)
+  );
+}
+
+function toReadToolModelOutput(output: unknown): ReadToolModelOutput {
+  if (typeof output === "string") {
+    return { type: "text", value: output };
+  }
+
+  if (isReadToolContentOutput(output)) {
+    return output;
+  }
+
+  return { type: "json", value: output ?? null };
+}
+
+function formatSandboxReadResult(
+  result: SandboxReadResult,
+  options?: ToolExecutionOptions,
+): string | ReadToolContentOutput {
+  switch (result.type) {
+    case "text":
+      return withLargeContentWarning(result.text);
+
+    case "unsupported":
+      return result.text;
+
+    case "image": {
+      const note =
+        result.text ?? `Read image (${result.mediaType}). The image is attached as model input.`;
+
+      if (!supportsImageInput(options)) {
+        return fallbackText(
+          `Read image (${result.mediaType}), but the active model does not support image input.`,
+          result.text,
+        );
+      }
+
+      return {
+        type: "content",
+        value: [
+          textPart(note),
+          { type: "image-data", data: result.data, mediaType: result.mediaType },
+        ],
+      };
+    }
+
+    case "file": {
+      const note =
+        result.text ??
+        `Read file${result.filename ? ` ${result.filename}` : ""} (${result.mediaType}). The file is attached as model input.`;
+
+      if (result.data == null) {
+        return note;
+      }
+
+      if (!supportsFileInput(options)) {
+        return fallbackText(
+          `Read file${result.filename ? ` ${result.filename}` : ""} (${result.mediaType}), but the active model does not support file input.`,
+          result.text,
+        );
+      }
+
+      return {
+        type: "content",
+        value: [
+          textPart(note),
+          {
+            type: "file-data",
+            data: result.data,
+            mediaType: result.mediaType,
+            filename: result.filename,
+          },
+        ],
+      };
+    }
+
+    case "rendered_pages": {
+      const intro =
+        result.text ??
+        `Read ${result.pages.length} rendered page${result.pages.length === 1 ? "" : "s"}.`;
+
+      if (!supportsImageInput(options)) {
+        const pages = result.pages
+          .map((page) => `page ${page.page} (${page.mediaType})`)
+          .join(", ");
+        return fallbackText(
+          `Read rendered pages, but the active model does not support image input. Rendered pages omitted: ${pages}.`,
+          result.text,
+        );
+      }
+
+      return {
+        type: "content",
+        value: result.pages.flatMap((page, index) => [
+          ...(index === 0 ? [textPart(intro)] : []),
+          textPart(`Page ${page.page}`),
+          {
+            type: "image-data" as const,
+            data: page.data,
+            mediaType: page.mediaType,
+          },
+        ]),
+      };
+    }
+  }
+}
 
 // =============================================================================
 // Read Tool
@@ -59,26 +240,28 @@ export function createReadTool(backend: BackendProtocol) {
         .optional()
         .describe(`Maximum lines to read (default: ${DEFAULT_READ_LIMIT})`),
     }),
-    execute: async ({
-      file_path,
-      offset,
-      limit,
-    }: {
-      file_path: string;
-      offset?: number;
-      limit?: number;
-    }) => {
+    execute: async (
+      {
+        file_path,
+        offset,
+        limit,
+      }: {
+        file_path: string;
+        offset?: number;
+        limit?: number;
+      },
+      options?: ToolExecutionOptions,
+    ) => {
       const effectiveLimit = limit ?? DEFAULT_READ_LIMIT;
       const content = await backend.read(file_path, offset, effectiveLimit);
 
-      // Add warning for large content
-      if (content.length > LARGE_CONTENT_WARNING_CHARS) {
-        const estimatedTokens = Math.round(content.length / 4);
-        return `[Warning: Large file content (~${estimatedTokens} tokens). Consider using offset/limit to read specific sections.]\n\n${content}`;
+      if (isSandboxReadResult(content)) {
+        return formatSandboxReadResult(content, options);
       }
 
-      return content;
+      return withLargeContentWarning(content);
     },
+    toModelOutput: ({ output }: { output: unknown }) => toReadToolModelOutput(output),
   });
 }
 

--- a/packages/agent-sdk/src/tools/filesystem.ts
+++ b/packages/agent-sdk/src/tools/filesystem.ts
@@ -29,10 +29,10 @@ type ReadToolContentPart =
   | { type: "image-data"; data: string; mediaType: string }
   | { type: "file-data"; data: string; mediaType: string; filename?: string };
 
-type ReadToolContentOutput = {
+interface ReadToolContentOutput {
   type: "content";
   value: ReadToolContentPart[];
-};
+}
 
 type ReadToolModelOutput =
   | { type: "text"; value: string }
@@ -120,7 +120,7 @@ function formatSandboxReadResult(
       return withLargeContentWarning(result.text);
 
     case "unsupported":
-      return result.text;
+      return withLargeContentWarning(result.text);
 
     case "image": {
       const note =
@@ -143,13 +143,16 @@ function formatSandboxReadResult(
     }
 
     case "file": {
+      if (result.data == null) {
+        return withLargeContentWarning(
+          result.text ??
+            `Read file${result.filename ? ` ${result.filename}` : ""} (${result.mediaType}), but no file payload is attached.`,
+        );
+      }
+
       const note =
         result.text ??
         `Read file${result.filename ? ` ${result.filename}` : ""} (${result.mediaType}). The file is attached as model input.`;
-
-      if (result.data == null) {
-        return note;
-      }
 
       if (!supportsFileInput(options)) {
         return fallbackText(
@@ -189,15 +192,17 @@ function formatSandboxReadResult(
 
       return {
         type: "content",
-        value: result.pages.flatMap((page, index) => [
-          ...(index === 0 ? [textPart(intro)] : []),
-          textPart(`Page ${page.page}`),
-          {
-            type: "image-data" as const,
-            data: page.data,
-            mediaType: page.mediaType,
-          },
-        ]),
+        value: [
+          textPart(intro),
+          ...result.pages.flatMap((page) => [
+            textPart(`Page ${page.page}`),
+            {
+              type: "image-data" as const,
+              data: page.data,
+              mediaType: page.mediaType,
+            },
+          ]),
+        ],
       };
     }
   }

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -43,6 +43,59 @@ export type {
   UIMessage,
 };
 
+/**
+ * Declares which typed content parts a language model can accept as input.
+ *
+ * The SDK uses these capabilities when projecting backend read results and
+ * replayed messages. Omitted fields mean "unknown", so typed content is allowed
+ * through and the provider remains responsible for validation.
+ *
+ * @category Types
+ */
+export interface ModelInputCapabilities {
+  /**
+   * Whether the model supports image inputs.
+   *
+   * Set to `false` to downgrade image read results to text fallbacks before
+   * sending the request.
+   *
+   * @defaultValue undefined
+   */
+  imageInput?: boolean;
+
+  /**
+   * Whether the model supports file/document inputs.
+   *
+   * Set to `false` to downgrade file read results to text fallbacks before
+   * sending the request.
+   *
+   * @defaultValue undefined
+   */
+  fileInput?: boolean;
+}
+
+/**
+ * Resolver function that maps a model to its input capabilities.
+ *
+ * @param model - Active {@link LanguageModel} for the current request
+ * @returns The {@link ModelInputCapabilities} for the model, or `undefined`
+ * when capabilities are unknown
+ *
+ * @category Types
+ */
+export type ModelInputCapabilitiesResolverFn = (
+  model: LanguageModel,
+) => ModelInputCapabilities | undefined;
+
+/**
+ * Static or model-aware resolver for input capabilities.
+ *
+ * @category Types
+ */
+export type ModelInputCapabilitiesResolver =
+  | ModelInputCapabilities
+  | ModelInputCapabilitiesResolverFn;
+
 // =============================================================================
 // Tool Interrupt Types
 // =============================================================================
@@ -334,6 +387,37 @@ export type AgentUIMessage = UIMessage<AgentDataTypes>;
 export interface AgentOptions {
   /** The AI model to use for generation */
   model: LanguageModel;
+
+  /**
+   * Declares multimodal input support for the active model.
+   *
+   * Backends can return typed read results such as images, files, and rendered
+   * pages. The SDK uses these capabilities to decide whether to pass those parts
+   * through to the model or downgrade them to clear text fallbacks. Provide a
+   * resolver when primary and fallback models have different capabilities.
+   *
+   * Omitted fields mean "unknown", so typed content is preserved.
+   *
+   * @example
+   * ```typescript
+   * const agent = createAgent({
+   *   model,
+   *   modelCapabilities: { imageInput: true, fileInput: false },
+   * });
+   *
+   * const agentWithResolver = createAgent({
+   *   model: activeModel,
+   *   fallbackModel,
+   *   modelCapabilities: (model) =>
+   *     model === fallbackModel
+   *       ? { imageInput: false, fileInput: false }
+   *       : { imageInput: true, fileInput: true },
+   * });
+   * ```
+   *
+   * @defaultValue undefined
+   */
+  modelCapabilities?: ModelInputCapabilitiesResolver;
 
   /**
    * Fallback model to use when the primary model fails.
@@ -2262,6 +2346,22 @@ export type StreamPart =
   | { type: "tool-result"; toolCallId: string; toolName: string; output: unknown }
   | { type: "finish"; finishReason: FinishReason; usage?: LanguageModelUsage }
   | { type: "error"; error: Error }
+  // Lifecycle events. A "turn" is one round-trip to the model (one assistant
+  // message). A `generate()`/`stream()` invocation produces one or more turns
+  // until the loop terminates. These events make turn boundaries explicit so
+  // callers do not need to derive them from `step-start`/`step-finish` chunks
+  // or invent message IDs themselves.
+  //
+  // `turn-start` always precedes the first content delta of a new assistant
+  // message. `turn-end` always follows the last delta of that message. Tools
+  // executed within the turn appear between them as `tool-call`/`tool-result`.
+  | { type: "turn-start"; messageId?: string }
+  | {
+      type: "turn-end";
+      messageId?: string;
+      finishReason?: FinishReason;
+      usage?: LanguageModelUsage;
+    }
   // Agent-specific events
   | { type: "subagent-spawn"; data: AgentDataTypes["subagent-spawn"] }
   | { type: "subagent-complete"; data: AgentDataTypes["subagent-complete"] }

--- a/packages/agent-sdk/tests/filesystem-tools.test.ts
+++ b/packages/agent-sdk/tests/filesystem-tools.test.ts
@@ -214,6 +214,27 @@ describe("Filesystem Tools", () => {
       });
     });
 
+    it("should downgrade file read results when the model cannot read files", async () => {
+      const fileBackend = {
+        ...backend,
+        read: () => ({
+          type: "file" as const,
+          text: "PDF document.",
+          data: "JVBERi0xLjQ=",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        }),
+      };
+      const read = createReadTool(fileBackend);
+
+      const result = await read.execute({ file_path: "/report.pdf" }, {
+        experimental_context: { agentSdk: { modelCapabilities: { fileInput: false } } },
+      } as any);
+
+      expect(result).toContain("does not support file input");
+      expect(result).toContain("PDF document.");
+    });
+
     it("should preserve empty string file payloads", async () => {
       const fileBackend = {
         ...backend,
@@ -243,6 +264,23 @@ describe("Filesystem Tools", () => {
       });
     });
 
+    it("should not claim file payload is attached when data is missing", async () => {
+      const fileBackend = {
+        ...backend,
+        read: () => ({
+          type: "file" as const,
+          mediaType: "application/pdf",
+          filename: "missing.pdf",
+        }),
+      };
+      const read = createReadTool(fileBackend);
+
+      const result = await read.execute({ file_path: "/missing.pdf" }, {} as any);
+
+      expect(result).toContain("no file payload is attached");
+      expect(result).not.toContain("attached as model input");
+    });
+
     it("should label each rendered page before its image", async () => {
       const pageBackend = {
         ...backend,
@@ -269,6 +307,50 @@ describe("Filesystem Tools", () => {
           { type: "image-data", data: "page-13", mediaType: "image/png" },
         ],
       });
+    });
+
+    it("should preserve rendered page intro when no pages are returned", async () => {
+      const pageBackend = {
+        ...backend,
+        read: () => ({
+          type: "rendered_pages" as const,
+          text: "Rendered PDF pages.",
+          pages: [],
+        }),
+      };
+      const read = createReadTool(pageBackend);
+
+      const result = await read.execute({ file_path: "/report.pdf" }, {} as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [{ type: "text", text: "Rendered PDF pages." }],
+      });
+    });
+
+    it("should downgrade rendered page reads when the model cannot read images", async () => {
+      const pageBackend = {
+        ...backend,
+        read: () => ({
+          type: "rendered_pages" as const,
+          text: "Rendered PDF pages.",
+          pages: [
+            { page: 12, data: "page-12", mediaType: "image/png" },
+            { page: 13, data: "page-13", mediaType: "image/png" },
+          ],
+        }),
+      };
+      const read = createReadTool(pageBackend);
+
+      const result = await read.execute({ file_path: "/report.pdf" }, {
+        experimental_context: { agentSdk: { modelCapabilities: { imageInput: false } } },
+      } as any);
+
+      expect(result).toContain("does not support image input");
+      expect(result).toContain("Rendered PDF pages.");
+      expect(result).toContain("page 12 (image/png)");
+      expect(result).toContain("page 13 (image/png)");
+      expect(result).not.toContain("image-data");
     });
   });
 

--- a/packages/agent-sdk/tests/filesystem-tools.test.ts
+++ b/packages/agent-sdk/tests/filesystem-tools.test.ts
@@ -96,6 +96,180 @@ describe("Filesystem Tools", () => {
       expect(result).toContain("[Warning: Large file content");
       expect(result).toContain("tokens");
     });
+
+    it("should return image read results as tool content", async () => {
+      const imageBackend = {
+        ...backend,
+        read: () => ({
+          type: "image" as const,
+          text: "Screenshot of the app.",
+          data: "iVBORw0KGgo=",
+          mediaType: "image/png",
+        }),
+      };
+      const read = createReadTool(imageBackend);
+
+      const result = await read.execute({ file_path: "/screenshot.png" }, {} as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [
+          { type: "text", text: "Screenshot of the app." },
+          { type: "image-data", data: "iVBORw0KGgo=", mediaType: "image/png" },
+        ],
+      });
+    });
+
+    it("should handle typed reads when executed without tool options", async () => {
+      const imageBackend = {
+        ...backend,
+        read: () => ({
+          type: "image" as const,
+          text: "Screenshot of the app.",
+          data: "iVBORw0KGgo=",
+          mediaType: "image/png",
+        }),
+      };
+      const read = createReadTool(imageBackend);
+
+      const result = await read.execute?.({ file_path: "/screenshot.png" }, undefined as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [
+          { type: "text", text: "Screenshot of the app." },
+          { type: "image-data", data: "iVBORw0KGgo=", mediaType: "image/png" },
+        ],
+      });
+    });
+
+    it("should preserve content read results for model output", async () => {
+      const imageBackend = {
+        ...backend,
+        read: () => ({
+          type: "image" as const,
+          text: "Screenshot of the app.",
+          data: "iVBORw0KGgo=",
+          mediaType: "image/png",
+        }),
+      };
+      const read = createReadTool(imageBackend);
+      const result = await read.execute({ file_path: "/screenshot.png" }, {} as any);
+
+      const modelOutput = await read.toModelOutput?.({
+        toolCallId: "call_1",
+        input: { file_path: "/screenshot.png" },
+        output: result,
+      });
+
+      expect(modelOutput).toEqual(result);
+    });
+
+    it("should downgrade image read results when the model cannot read images", async () => {
+      const imageBackend = {
+        ...backend,
+        read: () => ({
+          type: "image" as const,
+          text: "Screenshot of the app.",
+          data: "iVBORw0KGgo=",
+          mediaType: "image/png",
+        }),
+      };
+      const read = createReadTool(imageBackend);
+
+      const result = await read.execute({ file_path: "/screenshot.png" }, {
+        experimental_context: { agentSdk: { modelCapabilities: { imageInput: false } } },
+      } as any);
+
+      expect(result).toContain("does not support image input");
+      expect(result).toContain("Screenshot of the app.");
+    });
+
+    it("should return file read results as tool content", async () => {
+      const fileBackend = {
+        ...backend,
+        read: () => ({
+          type: "file" as const,
+          text: "PDF document.",
+          data: "JVBERi0xLjQ=",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        }),
+      };
+      const read = createReadTool(fileBackend);
+
+      const result = await read.execute({ file_path: "/report.pdf" }, {} as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [
+          { type: "text", text: "PDF document." },
+          {
+            type: "file-data",
+            data: "JVBERi0xLjQ=",
+            mediaType: "application/pdf",
+            filename: "report.pdf",
+          },
+        ],
+      });
+    });
+
+    it("should preserve empty string file payloads", async () => {
+      const fileBackend = {
+        ...backend,
+        read: () => ({
+          type: "file" as const,
+          text: "Empty PDF document.",
+          data: "",
+          mediaType: "application/pdf",
+          filename: "empty.pdf",
+        }),
+      };
+      const read = createReadTool(fileBackend);
+
+      const result = await read.execute({ file_path: "/empty.pdf" }, {} as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [
+          { type: "text", text: "Empty PDF document." },
+          {
+            type: "file-data",
+            data: "",
+            mediaType: "application/pdf",
+            filename: "empty.pdf",
+          },
+        ],
+      });
+    });
+
+    it("should label each rendered page before its image", async () => {
+      const pageBackend = {
+        ...backend,
+        read: () => ({
+          type: "rendered_pages" as const,
+          text: "Rendered PDF pages.",
+          pages: [
+            { page: 12, data: "page-12", mediaType: "image/png" },
+            { page: 13, data: "page-13", mediaType: "image/png" },
+          ],
+        }),
+      };
+      const read = createReadTool(pageBackend);
+
+      const result = await read.execute({ file_path: "/report.pdf" }, {} as any);
+
+      expect(result).toEqual({
+        type: "content",
+        value: [
+          { type: "text", text: "Rendered PDF pages." },
+          { type: "text", text: "Page 12" },
+          { type: "image-data", data: "page-12", mediaType: "image/png" },
+          { type: "text", text: "Page 13" },
+          { type: "image-data", data: "page-13", mediaType: "image/png" },
+        ],
+      });
+    });
   });
 
   describe("createWriteTool", () => {

--- a/packages/agent-sdk/tests/interrupt-resume-bugs.test.ts
+++ b/packages/agent-sdk/tests/interrupt-resume-bugs.test.ts
@@ -186,6 +186,71 @@ describe("Interrupt resume flow bugs", () => {
       const updatedCheckpoint = await checkpointer.load(threadId);
       expect(updatedCheckpoint?.pendingInterrupt).toBeDefined();
     });
+
+    it("should preserve toModelOutput content after custom interrupt resume", async () => {
+      const checkpointer = new MemorySaver();
+      const threadId = "custom-content-output-thread";
+      const toolCallId = "call_custom_content";
+      const interruptId = `int_${toolCallId}`;
+      const contentOutput = {
+        type: "content" as const,
+        value: [
+          { type: "text" as const, text: "Screenshot" },
+          { type: "image-data" as const, data: "iVBORw0KGgo=", mediaType: "image/png" },
+        ],
+      };
+
+      const checkpoint: Checkpoint = {
+        threadId,
+        step: 1,
+        messages: [{ role: "user", content: "Read an image after asking" }],
+        state: { todos: [], files: {} },
+        pendingInterrupt: createInterrupt({
+          id: interruptId,
+          threadId,
+          type: "custom",
+          toolCallId,
+          toolName: "read_after_interrupt",
+          request: { file_path: "/screenshot.png" },
+        }),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await checkpointer.save(checkpoint);
+
+      vi.mocked(generateText).mockResolvedValue({
+        text: "Done",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: "stop",
+        steps: [],
+      } as never);
+
+      const agent = createAgent({
+        model: createMockModel(),
+        checkpointer,
+        tools: {
+          read_after_interrupt: {
+            description: "Read after interrupt",
+            execute: async (_input: unknown, options: { interrupt?: () => Promise<unknown> }) => {
+              await options.interrupt?.();
+              return contentOutput;
+            },
+            toModelOutput: ({ output }: { output: unknown }) => output,
+          },
+        },
+      });
+
+      await agent.resume(threadId, interruptId, "approved");
+
+      const updatedCheckpoint = await checkpointer.load(threadId);
+      const toolMsg = updatedCheckpoint?.messages.find((m) => m.role === "tool");
+      const toolContent = toolMsg?.content as Array<{
+        type: string;
+        output: unknown;
+      }>;
+
+      expect(toolContent[0].output).toEqual(contentOutput);
+    });
   });
 
   describe("Bug 3: ToolResultOutput format", () => {
@@ -252,6 +317,69 @@ describe("Interrupt resume flow bugs", () => {
         type: expect.stringMatching(/^(text|json)$/),
         value: expect.anything(),
       });
+    });
+
+    it("should preserve tool toModelOutput content after approval resume", async () => {
+      const checkpointer = new MemorySaver();
+      const contentOutput = {
+        type: "content" as const,
+        value: [
+          { type: "text" as const, text: "Screenshot" },
+          { type: "image-data" as const, data: "iVBORw0KGgo=", mediaType: "image/png" },
+        ],
+      };
+      const toolExecuted = vi.fn().mockResolvedValue(contentOutput);
+      const threadId = "approval-content-output-thread";
+      const toolCallId = "call_content_output";
+
+      const checkpoint: Checkpoint = {
+        threadId,
+        step: 1,
+        messages: [{ role: "user", content: "Test" }],
+        state: { todos: [], files: {} },
+        pendingInterrupt: createApprovalInterrupt({
+          id: `int_${toolCallId}`,
+          threadId,
+          toolCallId,
+          toolName: "readImage",
+          args: { file_path: "/screenshot.png" },
+          step: 1,
+        }),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await checkpointer.save(checkpoint);
+
+      vi.mocked(generateText).mockResolvedValue({
+        text: "Done",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: "stop",
+        steps: [],
+      } as never);
+
+      const agent = createAgent({
+        model: createMockModel(),
+        checkpointer,
+        tools: {
+          readImage: {
+            description: "Read an image",
+            execute: toolExecuted,
+            toModelOutput: ({ output }: { output: unknown }) => output,
+          },
+        },
+      });
+
+      const interrupt = await agent.getInterrupt(threadId);
+      await agent.resume(threadId, interrupt!.id, { approved: true });
+
+      const updatedCheckpoint = await checkpointer.load(threadId);
+      const toolMsg = updatedCheckpoint?.messages.find((m) => m.role === "tool");
+      const toolContent = toolMsg?.content as Array<{
+        type: string;
+        output: unknown;
+      }>;
+
+      expect(toolContent[0].output).toEqual(contentOutput);
     });
 
     it("should use { type, value } format for denial result output", async () => {

--- a/packages/agent-sdk/tests/streaming-lifecycle-events.test.ts
+++ b/packages/agent-sdk/tests/streaming-lifecycle-events.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StreamPart } from "../src/index.js";
+import { createAgent } from "../src/index.js";
+import { createMockModel, resetMocks } from "./setup.js";
+
+// Mock the AI SDK so we can drive the underlying fullStream deterministically.
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateText: vi.fn(),
+    streamText: vi.fn(),
+    createUIMessageStream: vi.fn(),
+    createUIMessageStreamResponse: vi.fn(),
+  };
+});
+
+import { streamText } from "ai";
+
+describe("Stream lifecycle events", () => {
+  beforeEach(() => {
+    resetMocks();
+    vi.clearAllMocks();
+  });
+
+  it("emits turn-start before content and turn-end with messageId after content", async () => {
+    const model = createMockModel();
+    const agent = createAgent({ model });
+
+    const responseId = "msg_01ABC";
+    const usage = { promptTokens: 10, completionTokens: 4, totalTokens: 14 };
+
+    const mockStream = {
+      fullStream: (async function* () {
+        yield { type: "start-step" as const };
+        yield { type: "text-delta" as const, text: "Hello " };
+        yield { type: "text-delta" as const, text: "world" };
+        yield {
+          type: "finish-step" as const,
+          response: { id: responseId },
+          finishReason: "stop" as const,
+          usage,
+        };
+        yield {
+          type: "finish" as const,
+          finishReason: "stop" as const,
+          totalUsage: usage,
+        };
+      })(),
+      text: Promise.resolve("Hello world"),
+      usage: Promise.resolve(usage),
+      finishReason: Promise.resolve("stop" as const),
+      steps: Promise.resolve([]),
+    };
+    vi.mocked(streamText).mockReturnValue(mockStream as any);
+
+    const collected: StreamPart[] = [];
+    for await (const part of agent.stream({ prompt: "test" })) {
+      collected.push(part);
+    }
+
+    const types = collected.map((p) => p.type);
+    expect(types).toEqual(["turn-start", "text-delta", "text-delta", "turn-end", "finish"]);
+
+    const turnStart = collected.find((p) => p.type === "turn-start");
+    expect(turnStart).toBeDefined();
+    if (turnStart && turnStart.type === "turn-start") {
+      expect(turnStart.messageId).toBeUndefined();
+    }
+
+    const turnEnd = collected.find((p) => p.type === "turn-end");
+    expect(turnEnd).toBeDefined();
+    if (turnEnd && turnEnd.type === "turn-end") {
+      expect(turnEnd.messageId).toBe(responseId);
+      expect(turnEnd.finishReason).toBe("stop");
+      expect(turnEnd.usage).toEqual(usage);
+    }
+  });
+
+  it("brackets each turn in a multi-turn stream", async () => {
+    const model = createMockModel();
+    const agent = createAgent({ model });
+
+    const usage = { promptTokens: 8, completionTokens: 3, totalTokens: 11 };
+
+    const mockStream = {
+      fullStream: (async function* () {
+        // Turn 1: text + tool call (no result yet)
+        yield { type: "start-step" as const };
+        yield { type: "text-delta" as const, text: "Looking up..." };
+        yield {
+          type: "tool-call" as const,
+          toolCallId: "call_1",
+          toolName: "lookup",
+          input: { q: "x" },
+        };
+        yield {
+          type: "finish-step" as const,
+          response: { id: "msg_turn1" },
+          finishReason: "tool-calls" as const,
+          usage,
+        };
+        // Tool result happens between turns at the AI SDK level
+        yield {
+          type: "tool-result" as const,
+          toolCallId: "call_1",
+          toolName: "lookup",
+          output: { result: "ok" },
+        };
+        // Turn 2: model continuation
+        yield { type: "start-step" as const };
+        yield { type: "text-delta" as const, text: "Done." };
+        yield {
+          type: "finish-step" as const,
+          response: { id: "msg_turn2" },
+          finishReason: "stop" as const,
+          usage,
+        };
+        yield {
+          type: "finish" as const,
+          finishReason: "stop" as const,
+          totalUsage: usage,
+        };
+      })(),
+      text: Promise.resolve("Looking up...Done."),
+      usage: Promise.resolve(usage),
+      finishReason: Promise.resolve("stop" as const),
+      steps: Promise.resolve([]),
+    };
+    vi.mocked(streamText).mockReturnValue(mockStream as any);
+
+    const collected: StreamPart[] = [];
+    for await (const part of agent.stream({ prompt: "test" })) {
+      collected.push(part);
+    }
+
+    const turnEnds = collected.filter((p) => p.type === "turn-end");
+    expect(turnEnds).toHaveLength(2);
+    if (turnEnds[0]?.type === "turn-end") {
+      expect(turnEnds[0].messageId).toBe("msg_turn1");
+      expect(turnEnds[0].finishReason).toBe("tool-calls");
+    }
+    if (turnEnds[1]?.type === "turn-end") {
+      expect(turnEnds[1].messageId).toBe("msg_turn2");
+      expect(turnEnds[1].finishReason).toBe("stop");
+    }
+
+    // Tool call/result must appear between turn boundaries.
+    const turnStartIdx = collected.findIndex((p) => p.type === "turn-start");
+    const firstTurnEndIdx = collected.findIndex((p) => p.type === "turn-end");
+    const toolCallIdx = collected.findIndex((p) => p.type === "tool-call");
+    const toolResultIdx = collected.findIndex((p) => p.type === "tool-result");
+    expect(turnStartIdx).toBeLessThan(toolCallIdx);
+    expect(toolCallIdx).toBeLessThan(firstTurnEndIdx);
+    // Tool-result lands after the first turn-end (AI SDK emits it between
+    // step boundaries) but before the next turn-start.
+    expect(toolResultIdx).toBeGreaterThan(firstTurnEndIdx);
+    const secondTurnStartIdx = collected.findIndex(
+      (p, i) => i > firstTurnEndIdx && p.type === "turn-start",
+    );
+    expect(toolResultIdx).toBeLessThan(secondTurnStartIdx);
+  });
+
+  it("emits turn-start/turn-end without messageId when finish-step has no response id", async () => {
+    const model = createMockModel();
+    const agent = createAgent({ model });
+
+    const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+    const mockStream = {
+      fullStream: (async function* () {
+        yield { type: "start-step" as const };
+        yield { type: "text-delta" as const, text: "ok" };
+        // Some providers omit response metadata; we should still surface
+        // turn-end and just leave messageId undefined.
+        yield {
+          type: "finish-step" as const,
+          response: {},
+          finishReason: "stop" as const,
+          usage,
+        };
+        yield {
+          type: "finish" as const,
+          finishReason: "stop" as const,
+          totalUsage: usage,
+        };
+      })(),
+      text: Promise.resolve("ok"),
+      usage: Promise.resolve(usage),
+      finishReason: Promise.resolve("stop" as const),
+      steps: Promise.resolve([]),
+    };
+    vi.mocked(streamText).mockReturnValue(mockStream as any);
+
+    const collected: StreamPart[] = [];
+    for await (const part of agent.stream({ prompt: "test" })) {
+      collected.push(part);
+    }
+
+    const turnEnd = collected.find((p) => p.type === "turn-end");
+    expect(turnEnd).toBeDefined();
+    if (turnEnd && turnEnd.type === "turn-end") {
+      expect(turnEnd.messageId).toBeUndefined();
+      expect(turnEnd.finishReason).toBe("stop");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add typed `SandboxReadResult` support to the backend `read()` contract for text, image, file, rendered page, and unsupported reads.
- Project typed image/file reads from the default `read` tool into AI SDK tool-result content, with text fallbacks when `AgentOptions.modelCapabilities` says the active model cannot accept image/file inputs.
- Downgrade replayed tool-result content safely when model capabilities change across requests, including legacy `result` parts and JSON-wrapped content outputs.
- Add stream `turn-start` / `turn-end` lifecycle events and the accompanying pi-agent-core comparison research note that were already on this branch.

Closes #127

## Testing

- [x] `bun run check`
- [x] `bun run --filter '@lleverage-ai/agent-sdk' type-check`
- [x] `bun run --filter '@lleverage-ai/agent-sdk' test -- tests/filesystem-tools.test.ts tests/interrupt-resume-bugs.test.ts tests/streaming-lifecycle-events.test.ts`
- [x] `bun run --filter '@lleverage-ai/agent-sdk' test`
- [x] Pre-push hook: `biome check .` and full workspace `bun run test`

## Breaking Changes

None. Existing string read behavior remains supported; typed read results are additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streams now emit explicit turn-start and turn-end events per assistant message, optionally including message ID, finish reason and usage.
  * Backend read() can return structured typed results for text, images, files, rendered pages and unsupported content.
  * Read tools respect model input capabilities and downgrade or project content appropriately for model-facing outputs.

* **Documentation**
  * Added research analysis comparing agent architecture and lifecycle semantics.

* **Tests**
  * Added coverage for typed reads, streaming lifecycle sequencing and interrupt/resume preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->