### PR TITLE
Fix transcript turn boundaries and add prompt diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `PreToolUse` hooks now support `respondWith` in `HookSpecificOutput` to short-circuit tool execution and return a synthetic result without calling the original tool. `PostToolUse` hooks still fire with the synthetic result for observability, and the `PostToolUseInput` carries `tool_result_synthetic: true` so audit/log/metrics hooks can distinguish intercepted calls from real ones
+- `PromptComponent` now supports `stability` and `budget` metadata, and `PromptBuilder.buildWithDiagnostics()` returns prompt and section fingerprints for lightweight prompt-cache diagnostics
+
+### Fixed
+
+- `@lleverage-ai/agent-threads` accumulation now preserves assistant turn boundaries when `tool-result` events arrive before `step-finished`, queuing tool results until the assistant step is committed so step metadata remains attached to the correct message
 
 ## [0.1.0-alpha.3] - 2026-04-23
 

--- a/docs/prompt-builder.md
+++ b/docs/prompt-builder.md
@@ -241,10 +241,20 @@ Each component contributes one section to the final prompt:
 interface PromptComponent {
   name: string;
   priority?: number;
+  stability?: "static" | "dynamic";
+  budget?: {
+    maxTokens?: number;
+    optional?: boolean;
+  };
   condition?: (ctx: PromptContext) => boolean;
   render: (ctx: PromptContext) => string;
 }
 ```
+
+`stability` and `budget` are metadata for diagnostics and host policy. The
+builder does not automatically trim sections. Static sections are expected to
+stay stable across turns for the same agent configuration; dynamic sections may
+change with runtime context.
 
 ### PromptBuilder
 
@@ -255,6 +265,21 @@ The builder:
 3. sorts them by priority
 4. renders them
 5. joins non-empty output with blank lines
+
+Use `buildWithDiagnostics()` when you need prompt-cache diagnostics:
+
+```typescript
+const result = builder.buildWithDiagnostics(context);
+
+console.log(result.fingerprint);
+for (const section of result.sections) {
+  console.log(section.name, section.stability, section.fingerprint);
+}
+```
+
+The returned diagnostics include the final prompt, a prompt fingerprint, and
+per-section fingerprints with effective priority, stability, optional budget
+metadata, and rendered character counts.
 
 ## Customization Patterns
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -316,7 +316,14 @@ export {
   VirtualMCPServer,
 } from "./mcp/index.js";
 // Prompt Builder types
-export type { PromptComponent, PromptContext } from "./prompt-builder/index.js";
+export type {
+  PromptBuildResult,
+  PromptComponent,
+  PromptComponentBudget,
+  PromptComponentStability,
+  PromptContext,
+  PromptSectionDiagnostics,
+} from "./prompt-builder/index.js";
 export type {
   PromptInstructionLayer,
   PromptLoadedSkill,

--- a/packages/agent-sdk/src/prompt-builder/components.ts
+++ b/packages/agent-sdk/src/prompt-builder/components.ts
@@ -139,6 +139,7 @@ function renderStructuredEntries(
 export const identityComponent: PromptComponent = {
   name: "identity",
   priority: 100,
+  stability: "static",
   render: () =>
     "You are an interactive agent. Your job is to help the user achieve their goal using the instructions below and the tools available to you.",
 };
@@ -153,6 +154,7 @@ export const identityComponent: PromptComponent = {
 export const interactionContractComponent: PromptComponent = {
   name: "interaction-contract",
   priority: 95,
+  stability: "static",
   render: () => `# Interaction Contract
 
 - All text you output outside of tool use is shown directly to the user.
@@ -171,6 +173,7 @@ export const interactionContractComponent: PromptComponent = {
 export const actionPolicyComponent: PromptComponent = {
   name: "action-policy",
   priority: 90,
+  stability: "static",
   render: () => `# Action Policy
 
 - Choose the simplest effective action that advances the user's goal.
@@ -193,6 +196,7 @@ export const actionPolicyComponent: PromptComponent = {
 export const instructionLayersComponent: PromptComponent = {
   name: "instruction-layers",
   priority: 87,
+  stability: "dynamic",
   condition: (ctx) => resolveInstructionLayers(ctx).length > 0,
   render: (ctx) => {
     const layers = resolveInstructionLayers(ctx);
@@ -224,6 +228,7 @@ ${renderedLayers.join("\n\n")}`;
 export const capabilitySummaryComponent: PromptComponent = {
   name: "capability-summary",
   priority: 85,
+  stability: "dynamic",
   render: (ctx) => {
     const capabilities: string[] = [];
     const hasWorkspaceAccess = hasWorkspaceTool(ctx);
@@ -293,6 +298,7 @@ export const capabilitySummaryComponent: PromptComponent = {
 export const skillLoadingPolicyComponent: PromptComponent = {
   name: "skill-loading-policy",
   priority: 80,
+  stability: "static",
   condition: (ctx) => hasSkillLoadingCapability(ctx) && ctx.permissionMode !== "plan",
   render: () => `# Skill Loading
 
@@ -311,6 +317,7 @@ export const skillLoadingPolicyComponent: PromptComponent = {
 export const memoryPolicyComponent: PromptComponent = {
   name: "memory-policy",
   priority: 60,
+  stability: "static",
   condition: (ctx) => ctx.memoryAvailable ?? true,
   render: () => `# Memory
 
@@ -329,6 +336,7 @@ export const memoryPolicyComponent: PromptComponent = {
 export const recalledMemoryComponent: PromptComponent = {
   name: "recalled-memory",
   priority: 62,
+  stability: "dynamic",
   condition: (ctx) => hasNonEmptyMemoryEntries(ctx.memory?.recall),
   render: (ctx) =>
     renderStructuredEntries("# Recalled Memory", ctx.memory?.recall ?? [], {
@@ -352,6 +360,7 @@ export const recalledMemoryComponent: PromptComponent = {
 export const toolsComponent: PromptComponent = {
   name: "tools-listing",
   priority: 70,
+  stability: "dynamic",
   condition: (ctx) => ctx.tools !== undefined && ctx.tools.length > 0,
   render: (ctx) => {
     const toolLines = ctx.tools!.map((t) => `- **${t.name}**: ${t.description}`);
@@ -375,6 +384,7 @@ export const toolsComponent: PromptComponent = {
 export const skillsComponent: PromptComponent = {
   name: "skills-listing",
   priority: 65,
+  stability: "dynamic",
   condition: (ctx) => ctx.skills !== undefined && ctx.skills.length > 0,
   render: (ctx) => {
     const skillLines = ctx.skills!.map((s) => `- **${s.name}**: ${s.description}`);
@@ -397,6 +407,7 @@ export const skillsComponent: PromptComponent = {
 export const capabilitiesComponent: PromptComponent = {
   name: "capabilities",
   priority: 60,
+  stability: "dynamic",
   render: (ctx) => {
     const capabilities: string[] = [];
 
@@ -437,6 +448,7 @@ export const capabilitiesComponent: PromptComponent = {
 export const contextComponent: PromptComponent = {
   name: "context",
   priority: 50,
+  stability: "dynamic",
   condition: (ctx) => !!ctx.threadId || !!(ctx.currentMessages && ctx.currentMessages.length > 0),
   render: (ctx) => {
     const parts: string[] = [];
@@ -474,6 +486,7 @@ export const contextComponent: PromptComponent = {
 export const pluginsComponent: PromptComponent = {
   name: "plugins-listing",
   priority: 68,
+  stability: "dynamic",
   condition: (ctx) => ctx.plugins !== undefined && ctx.plugins.length > 0,
   render: (ctx) => {
     const pluginLines = ctx.plugins!.map((p) => `- **${p.name}**: ${p.description}`);
@@ -497,6 +510,7 @@ export const pluginsComponent: PromptComponent = {
 export const permissionModeComponent: PromptComponent = {
   name: "permission-mode",
   priority: 55,
+  stability: "dynamic",
   condition: (ctx) => !!ctx.permissionMode,
   render: (ctx) => {
     const mode = ctx.permissionMode!;

--- a/packages/agent-sdk/src/prompt-builder/delegation-component.ts
+++ b/packages/agent-sdk/src/prompt-builder/delegation-component.ts
@@ -55,6 +55,7 @@ user's goal.
 export const delegationComponent: PromptComponent = {
   name: "delegation-instructions",
   priority: 75,
+  stability: "dynamic",
   condition: (ctx) => ctx.custom?.hasSubagents === true,
   render: (ctx) => {
     // Allow custom delegation instructions to override default

--- a/packages/agent-sdk/src/prompt-builder/index.ts
+++ b/packages/agent-sdk/src/prompt-builder/index.ts
@@ -205,6 +205,38 @@ export interface PromptContext {
 }
 
 /**
+ * Stability classification for a prompt component.
+ *
+ * Static components should render the same text across turns for the same
+ * agent configuration. Dynamic components may change with messages, memory,
+ * tools, permissions, or other runtime context.
+ *
+ * @category Types
+ */
+export type PromptComponentStability = "static" | "dynamic";
+
+/**
+ * Token-budget metadata for a prompt component.
+ *
+ * This is advisory metadata for diagnostics and host policy. The builder does
+ * not trim component output automatically.
+ *
+ * @category Types
+ */
+export interface PromptComponentBudget {
+  /**
+   * Optional maximum token budget expected for this component.
+   */
+  maxTokens?: number;
+
+  /**
+   * Whether this component may be omitted by host policy when prompt budget is tight.
+   * @defaultValue false
+   */
+  optional?: boolean;
+}
+
+/**
  * A component that contributes to the system prompt.
  *
  * Components are sorted by priority (higher = rendered earlier in prompt)
@@ -240,6 +272,22 @@ export interface PromptComponent {
   priority?: number;
 
   /**
+   * Whether this component is expected to be stable across turns.
+   *
+   * `static` sections are good prompt-cache anchors. `dynamic` sections are
+   * expected to vary with runtime context and can explain cache-prefix churn in
+   * diagnostics.
+   *
+   * @defaultValue "dynamic"
+   */
+  stability?: PromptComponentStability;
+
+  /**
+   * Optional advisory budget metadata for this component.
+   */
+  budget?: PromptComponentBudget;
+
+  /**
    * Optional condition to determine if this component should be included.
    * If not provided or returns true, the component is included.
    * @param ctx - The prompt context
@@ -253,6 +301,74 @@ export interface PromptComponent {
    * @returns The text to include in the system prompt
    */
   render: (ctx: PromptContext) => string;
+}
+
+/**
+ * Diagnostic information for a rendered prompt component.
+ *
+ * @category Context
+ */
+export interface PromptSectionDiagnostics {
+  /**
+   * Component name.
+   */
+  name: string;
+
+  /**
+   * Effective component priority used for ordering.
+   */
+  priority: number;
+
+  /**
+   * Stability classification for this rendered section.
+   */
+  stability: PromptComponentStability;
+
+  /**
+   * Optional advisory budget metadata from the component.
+   */
+  budget?: PromptComponentBudget;
+
+  /**
+   * Stable fingerprint of the rendered section text.
+   */
+  fingerprint: string;
+
+  /**
+   * Rendered section length in UTF-16 code units.
+   */
+  charCount: number;
+}
+
+/**
+ * Result returned by {@link PromptBuilder.buildWithDiagnostics}.
+ *
+ * @category Context
+ */
+export interface PromptBuildResult {
+  /**
+   * Final prompt string.
+   */
+  prompt: string;
+
+  /**
+   * Stable fingerprint of the final prompt string.
+   */
+  fingerprint: string;
+
+  /**
+   * Diagnostics for rendered, non-empty prompt sections.
+   */
+  sections: PromptSectionDiagnostics[];
+}
+
+function fingerprintText(text: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, "0")}`;
 }
 
 /**
@@ -369,6 +485,19 @@ export class PromptBuilder {
    * ```
    */
   build(context: PromptContext): string {
+    return this.buildWithDiagnostics(context).prompt;
+  }
+
+  /**
+   * Build the final prompt and return rendered section diagnostics.
+   *
+   * Diagnostics include component stability, advisory budget metadata, and
+   * content fingerprints suitable for prompt-cache debugging.
+   *
+   * @param context - The context to pass to components
+   * @returns The final prompt and per-section diagnostics
+   */
+  buildWithDiagnostics(context: PromptContext): PromptBuildResult {
     // Filter components by condition
     const activeComponents = this.components.filter((component) => {
       if (component.condition) {
@@ -385,10 +514,28 @@ export class PromptBuilder {
     });
 
     // Render and join
-    const parts = activeComponents.map((component) => component.render(context));
+    const renderedSections = activeComponents
+      .map((component) => {
+        const text = component.render(context);
+        return { component, text };
+      })
+      .filter(({ text }) => text.trim().length > 0);
 
     // Filter out empty strings and join with double newlines
-    return parts.filter((part) => part.trim().length > 0).join("\n\n");
+    const prompt = renderedSections.map(({ text }) => text).join("\n\n");
+
+    return {
+      prompt,
+      fingerprint: fingerprintText(prompt),
+      sections: renderedSections.map(({ component, text }) => ({
+        name: component.name,
+        priority: component.priority ?? 50,
+        stability: component.stability ?? "dynamic",
+        ...(component.budget !== undefined ? { budget: component.budget } : {}),
+        fingerprint: fingerprintText(text),
+        charCount: text.length,
+      })),
+    };
   }
 
   /**

--- a/packages/agent-sdk/src/prompt-builder/index.ts
+++ b/packages/agent-sdk/src/prompt-builder/index.ts
@@ -548,7 +548,7 @@ export class PromptBuilder {
         name: component.name,
         priority: component.priority ?? 50,
         stability: component.stability ?? "dynamic",
-        ...(component.budget !== undefined ? { budget: component.budget } : {}),
+        ...(component.budget !== undefined ? { budget: { ...component.budget } } : {}),
         fingerprint: fingerprintText(text),
         charCount: text.length,
       })),

--- a/packages/agent-sdk/src/prompt-builder/index.ts
+++ b/packages/agent-sdk/src/prompt-builder/index.ts
@@ -401,6 +401,32 @@ function fingerprintText(text: string): string {
 export class PromptBuilder {
   private components: PromptComponent[] = [];
 
+  private getActiveComponents(context: PromptContext): PromptComponent[] {
+    const activeComponents = this.components.filter((component) => {
+      if (component.condition) {
+        return component.condition(context);
+      }
+      return true;
+    });
+
+    activeComponents.sort((a, b) => {
+      const aPriority = a.priority ?? 50;
+      const bPriority = b.priority ?? 50;
+      return bPriority - aPriority;
+    });
+
+    return activeComponents;
+  }
+
+  private renderSections(context: PromptContext): Array<{ component: PromptComponent; text: string }> {
+    return this.getActiveComponents(context)
+      .map((component) => {
+        const text = component.render(context);
+        return { component, text };
+      })
+      .filter(({ text }) => text.trim().length > 0);
+  }
+
   /**
    * Register a single component.
    *
@@ -485,7 +511,9 @@ export class PromptBuilder {
    * ```
    */
   build(context: PromptContext): string {
-    return this.buildWithDiagnostics(context).prompt;
+    return this.renderSections(context)
+      .map(({ text }) => text)
+      .join("\n\n");
   }
 
   /**
@@ -496,30 +524,19 @@ export class PromptBuilder {
    *
    * @param context - The context to pass to components
    * @returns The final prompt and per-section diagnostics
+   * @throws {Error} When a component condition or render callback throws
+   *
+   * @example
+   * ```typescript
+   * const context: PromptContext = {
+   *   tools: [{ name: "read", description: "Read files" }],
+   * };
+   * const result: PromptBuildResult = builder.buildWithDiagnostics(context);
+   * console.log(result.fingerprint, result.sections);
+   * ```
    */
   buildWithDiagnostics(context: PromptContext): PromptBuildResult {
-    // Filter components by condition
-    const activeComponents = this.components.filter((component) => {
-      if (component.condition) {
-        return component.condition(context);
-      }
-      return true;
-    });
-
-    // Sort by priority (higher first)
-    activeComponents.sort((a, b) => {
-      const aPriority = a.priority ?? 50;
-      const bPriority = b.priority ?? 50;
-      return bPriority - aPriority;
-    });
-
-    // Render and join
-    const renderedSections = activeComponents
-      .map((component) => {
-        const text = component.render(context);
-        return { component, text };
-      })
-      .filter(({ text }) => text.trim().length > 0);
+    const renderedSections = this.renderSections(context);
 
     // Filter out empty strings and join with double newlines
     const prompt = renderedSections.map(({ text }) => text).join("\n\n");

--- a/packages/agent-sdk/tests/prompt-builder.test.ts
+++ b/packages/agent-sdk/tests/prompt-builder.test.ts
@@ -257,6 +257,24 @@ describe("PromptBuilder", () => {
         },
       ]);
     });
+
+    it("should clone budget metadata in diagnostics", () => {
+      const budget = { maxTokens: 128, optional: true };
+      const builder = new PromptBuilder().register({
+        name: "budgeted",
+        budget,
+        render: () => "Budgeted",
+      });
+
+      const result = builder.buildWithDiagnostics({});
+      result.sections[0]!.budget!.maxTokens = 64;
+
+      expect(budget.maxTokens).toBe(128);
+      expect(builder.buildWithDiagnostics({}).sections[0]!.budget).toEqual({
+        maxTokens: 128,
+        optional: true,
+      });
+    });
   });
 });
 

--- a/packages/agent-sdk/tests/prompt-builder.test.ts
+++ b/packages/agent-sdk/tests/prompt-builder.test.ts
@@ -191,6 +191,72 @@ describe("PromptBuilder", () => {
       const prompt = builder.build({ model: "claude-3-5-sonnet" });
       expect(prompt).toBe("Model: claude-3-5-sonnet");
     });
+
+    it("should build prompts with per-section diagnostics", () => {
+      const builder = new PromptBuilder()
+        .register({
+          name: "identity",
+          priority: 100,
+          stability: "static",
+          budget: { maxTokens: 128 },
+          render: () => "You are helpful.",
+        })
+        .register({
+          name: "context",
+          priority: 10,
+          stability: "dynamic",
+          budget: { maxTokens: 64, optional: true },
+          render: (ctx) => `Thread: ${ctx.threadId ?? "none"}`,
+        })
+        .register({
+          name: "empty",
+          priority: 50,
+          stability: "static",
+          render: () => "",
+        });
+
+      const result = builder.buildWithDiagnostics({ threadId: "thread-123" });
+
+      expect(result.prompt).toBe("You are helpful.\n\nThread: thread-123");
+      expect(result.fingerprint).toMatch(/^fnv1a32:[0-9a-f]{8}$/);
+      expect(result.sections).toEqual([
+        {
+          name: "identity",
+          priority: 100,
+          stability: "static",
+          budget: { maxTokens: 128 },
+          fingerprint: expect.stringMatching(/^fnv1a32:[0-9a-f]{8}$/),
+          charCount: "You are helpful.".length,
+        },
+        {
+          name: "context",
+          priority: 10,
+          stability: "dynamic",
+          budget: { maxTokens: 64, optional: true },
+          fingerprint: expect.stringMatching(/^fnv1a32:[0-9a-f]{8}$/),
+          charCount: "Thread: thread-123".length,
+        },
+      ]);
+    });
+
+    it("should default diagnostics to dynamic stability and priority 50", () => {
+      const builder = new PromptBuilder().register({
+        name: "defaulted",
+        render: () => "Default metadata",
+      });
+
+      const result = builder.buildWithDiagnostics({});
+
+      expect(result.sections).toEqual([
+        {
+          name: "defaulted",
+          priority: 50,
+          stability: "dynamic",
+          fingerprint: expect.stringMatching(/^fnv1a32:[0-9a-f]{8}$/),
+          charCount: "Default metadata".length,
+        },
+      ]);
+    });
   });
 });
 
@@ -211,6 +277,10 @@ describe("Default Components", () => {
 
     it("should have high priority", () => {
       expect(identityComponent.priority).toBe(100);
+    });
+
+    it("should be marked as static for diagnostics", () => {
+      expect(identityComponent.stability).toBe("static");
     });
   });
 
@@ -280,6 +350,10 @@ describe("Default Components", () => {
 
       expect(runtimeIndex).toBeLessThan(skillIndex);
       expect(skillIndex).toBeLessThan(memoryIndex);
+    });
+
+    it("should be marked as dynamic for diagnostics", () => {
+      expect(instructionLayersComponent.stability).toBe("dynamic");
     });
   });
 

--- a/packages/agent-threads/CHANGELOG.md
+++ b/packages/agent-threads/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ToolPartMetadata` is now constrained to JSON-serializable values so `ToolCallPart.metadata` and `ToolResultPart.metadata` align with canonical transcript persistence
 - `Accumulator` payload handling now validates tool event payloads before projecting them into canonical messages, reduces broad type assertions in the ledger reducer, and safely filters metadata keys during normalization/merge while keeping the stream event model open-world
+- `Accumulator` now preserves assistant turn boundaries when `tool-result` events arrive before `step-finished`, queuing tool results until the assistant step is committed so step metadata remains attached to the correct message
 
 ## [0.1.0-alpha.4] - 2026-04-14
 

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -39,6 +39,14 @@ interface PendingToolCall {
   metadata?: ToolPartMetadata;
 }
 
+interface PendingToolResult {
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+  isError: boolean;
+  metadata?: ToolPartMetadata;
+}
+
 interface FileEventPayload {
   mimeType: string;
   url: string;
@@ -347,6 +355,8 @@ export interface AccumulatorState {
   textBuffer: string;
   /** Pending tool calls awaiting results */
   pendingToolCalls: Map<string, PendingToolCall>;
+  /** Tool results received before their assistant step boundary closes */
+  pendingToolResults: PendingToolResult[];
   /** ID of the last committed message */
   lastMessageId: string | null;
 }
@@ -361,6 +371,7 @@ function createInitialState(): AccumulatorState {
     currentMessage: null,
     textBuffer: "",
     pendingToolCalls: new Map(),
+    pendingToolResults: [],
     lastMessageId: null,
   };
 }
@@ -402,6 +413,44 @@ function commitCurrentMessage(state: AccumulatorState): void {
   state.currentMessage = null;
 }
 
+function materializeToolResult(
+  state: AccumulatorState,
+  idGen: IdGenerator,
+  result: PendingToolResult,
+): void {
+  const toolMsg: CanonicalMessage = {
+    id: idGen(),
+    parentMessageId: state.lastMessageId,
+    role: "tool",
+    parts: [
+      {
+        type: "tool-result",
+        toolCallId: result.toolCallId,
+        toolName: result.toolName,
+        output: result.output,
+        isError: result.isError,
+        ...(result.metadata !== undefined ? { metadata: result.metadata } : {}),
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    metadata: { schemaVersion: 1 },
+  };
+  state.messages.push(toolMsg);
+  state.lastMessageId = toolMsg.id;
+}
+
+function flushPendingToolResults(state: AccumulatorState, idGen: IdGenerator): void {
+  if (state.pendingToolResults.length === 0) {
+    return;
+  }
+
+  const pendingResults = state.pendingToolResults;
+  state.pendingToolResults = [];
+  for (const result of pendingResults) {
+    materializeToolResult(state, idGen, result);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Reducer
 // ---------------------------------------------------------------------------
@@ -421,7 +470,8 @@ function createReducer(
         if (!_p) {
           break;
         }
-        flushTextBuffer(state);
+        commitCurrentMessage(state);
+        flushPendingToolResults(state, idGen);
         ensureCurrentMessage(state, idGen);
         break;
       }
@@ -526,34 +576,25 @@ function createReducer(
         if (!p) {
           break;
         }
-        // Commit the current assistant message first
-        commitCurrentMessage(state);
-
         const pending = state.pendingToolCalls.get(p.toolCallId);
         const toolName = p.toolName ?? pending?.toolName ?? "unknown";
         state.pendingToolCalls.delete(p.toolCallId);
 
         const metadata = mergeToolMetadata(pending?.metadata, p.metadata);
 
-        const toolMsg: CanonicalMessage = {
-          id: idGen(),
-          parentMessageId: state.lastMessageId,
-          role: "tool",
-          parts: [
-            {
-              type: "tool-result",
-              toolCallId: p.toolCallId,
-              toolName,
-              output: p.output,
-              isError: p.isError ?? false,
-              ...(metadata !== undefined ? { metadata } : {}),
-            },
-          ],
-          createdAt: new Date().toISOString(),
-          metadata: { schemaVersion: 1 },
+        const result: PendingToolResult = {
+          toolCallId: p.toolCallId,
+          toolName,
+          output: p.output,
+          isError: p.isError ?? false,
+          ...(metadata !== undefined ? { metadata } : {}),
         };
-        state.messages.push(toolMsg);
-        state.lastMessageId = toolMsg.id;
+
+        if (state.currentMessage) {
+          state.pendingToolResults.push(result);
+        } else {
+          materializeToolResult(state, idGen, result);
+        }
         break;
       }
 
@@ -582,6 +623,7 @@ function createReducer(
           }
         }
         commitCurrentMessage(state);
+        flushPendingToolResults(state, idGen);
         break;
       }
 
@@ -661,7 +703,8 @@ export function accumulateEvents(
   idGenerator?: IdGenerator,
   options?: { forkFromMessageId?: string },
 ): CanonicalMessage[] {
-  const config = createAccumulatorProjectorConfig(idGenerator);
+  const idGen = idGenerator ?? ulid;
+  const config = createAccumulatorProjectorConfig(idGen);
   // Empty fork IDs are treated as absent to avoid creating dangling parent links.
   if (options?.forkFromMessageId) {
     config.initialState.lastMessageId = options.forkFromMessageId;
@@ -671,5 +714,6 @@ export function accumulateEvents(
   // Flush any in-progress message (getState() returns a clone, so mutation is safe)
   const state = projector.getState();
   commitCurrentMessage(state);
+  flushPendingToolResults(state, idGen);
   return state.messages;
 }

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -217,10 +217,13 @@ function mergeToolMetadata(
 
     const baseValue = base[key];
     const overrideValue = override[key];
+    const hasOverride = Object.hasOwn(override, key);
     const mergedValue =
       isPlainObject(baseValue) && isPlainObject(overrideValue)
         ? mergeToolMetadata(sanitizeMetadataBag(baseValue), sanitizeMetadataBag(overrideValue))
-        : (overrideValue ?? baseValue);
+        : hasOverride
+          ? overrideValue
+          : baseValue;
 
     if (mergedValue !== undefined) {
       metadata[key] = mergedValue;

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -398,7 +398,10 @@ function ensureCurrentMessage(state: AccumulatorState, idGen: IdGenerator): void
 function commitCurrentMessage(state: AccumulatorState): void {
   if (!state.currentMessage) return;
   flushTextBuffer(state);
-  if (state.currentMessage.parts.length === 0) return;
+  if (state.currentMessage.parts.length === 0) {
+    state.currentMessage = null;
+    return;
+  }
 
   const msg: CanonicalMessage = {
     id: state.currentMessage.id,
@@ -482,6 +485,7 @@ function createReducer(
           break;
         }
         commitCurrentMessage(state);
+        flushPendingToolResults(state, idGen);
         const userMsg = {
           id: idGen(),
           parentMessageId: state.lastMessageId,

--- a/packages/agent-threads/src/ledger/accumulator.ts
+++ b/packages/agent-threads/src/ledger/accumulator.ts
@@ -555,6 +555,18 @@ function createReducer(
               ...(nextMetadata !== undefined ? { metadata: nextMetadata } : {}),
             });
           }
+          state.pendingToolResults = state.pendingToolResults.map((result) => {
+            if (result.toolCallId !== p.toolCallId) {
+              return result;
+            }
+
+            const nextMetadata = mergeToolMetadata(result.metadata, p.metadata);
+            return {
+              ...result,
+              toolName: p.toolName,
+              ...(nextMetadata !== undefined ? { metadata: nextMetadata } : {}),
+            };
+          });
         } else {
           const nextPart: ToolCallPart = {
             type: "tool-call",

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -285,6 +285,27 @@ describe("Accumulator", () => {
       expect(messages[2]!.parts).toEqual([{ type: "text", text: "Assistant reply" }]);
     });
 
+    it("discards empty assistant messages at step boundaries", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "stop" } },
+        { kind: "step-started", payload: { stepIndex: 1 } },
+        { kind: "text-delta", payload: { delta: "Next step" } },
+        { kind: "step-finished", payload: { stepIndex: 1, finishReason: "stop" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        id: "msg-2",
+        parentMessageId: null,
+        role: "assistant",
+        parts: [{ type: "text", text: "Next step" }],
+      });
+    });
+
     it("does not commit assistant turns on tool-result before step-finished", () => {
       const idGen = createCounterIdGenerator("msg");
       const storedEvents = wrapEvents([
@@ -403,6 +424,28 @@ describe("Accumulator", () => {
         parentMessageId: "msg-1",
         parts: [{ type: "tool-result", toolCallId: "tc-1", output: "a" }],
       });
+    });
+
+    it("flushes queued early tool results before user messages", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: { toolCallId: "tc-1", toolName: "read", input: { path: "/a.txt" } },
+        },
+        {
+          kind: "tool-result",
+          payload: { toolCallId: "tc-1", toolName: "read", output: "a", isError: false },
+        },
+        { kind: "user-message", payload: { content: "Next user turn" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+
+      expect(messages.map((message) => message.role)).toEqual(["assistant", "tool", "user"]);
+      expect(messages.map((message) => message.parentMessageId)).toEqual([null, "msg-1", "msg-2"]);
+      expect(messages[2]!.parts).toEqual([{ type: "text", text: "Next user turn" }]);
     });
   });
 

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -298,8 +298,8 @@ describe("Accumulator", () => {
       const messages = accumulateEvents(storedEvents, idGen);
 
       expect(messages).toHaveLength(1);
+      expect(messages[0]!.id).toBeDefined();
       expect(messages[0]).toMatchObject({
-        id: "msg-2",
         parentMessageId: null,
         role: "assistant",
         parts: [{ type: "text", text: "Next step" }],
@@ -1051,6 +1051,62 @@ describe("Accumulator", () => {
           toolLabel: "Found 3 invoices",
           skillName: "Email",
           skillIcon: "mail",
+        },
+      });
+    });
+
+    it("preserves explicit null metadata updates for queued early tool results", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              toolLabel: "Searching your inbox",
+              skillName: "Email",
+              skillIcon: "mail",
+            },
+          },
+        },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            output: "Found 3 emails",
+            isError: false,
+          },
+        },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              skillIcon: null,
+            },
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const resultPart = messages[1]!.parts[0]!;
+      expect(resultPart).toEqual({
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "search_emails",
+        output: "Found 3 emails",
+        isError: false,
+        metadata: {
+          toolLabel: "Searching your inbox",
+          skillName: "Email",
+          skillIcon: null,
         },
       });
     });

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -998,5 +998,61 @@ describe("Accumulator", () => {
         },
       });
     });
+
+    it("propagates duplicate tool-call metadata updates after an early tool-result", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              toolLabel: "Searching your inbox",
+              skillName: "Email",
+              skillIcon: "mail",
+            },
+          },
+        },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            output: "Found 3 emails",
+            isError: false,
+          },
+        },
+        {
+          kind: "tool-call",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search_emails",
+            input: { query: "invoice" },
+            metadata: {
+              toolLabel: "Found 3 invoices",
+            },
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+      const resultPart = messages[1]!.parts[0]!;
+      expect(resultPart).toEqual({
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "search_emails",
+        output: "Found 3 emails",
+        isError: false,
+        metadata: {
+          toolLabel: "Found 3 invoices",
+          skillName: "Email",
+          skillIcon: "mail",
+        },
+      });
+    });
   });
 });

--- a/packages/agent-threads/tests/ledger/accumulator.test.ts
+++ b/packages/agent-threads/tests/ledger/accumulator.test.ts
@@ -284,6 +284,126 @@ describe("Accumulator", () => {
       expect(messages[2]!.parentMessageId).toBe("msg-2");
       expect(messages[2]!.parts).toEqual([{ type: "text", text: "Assistant reply" }]);
     });
+
+    it("does not commit assistant turns on tool-result before step-finished", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        { kind: "text-delta", payload: { delta: "I'll check." } },
+        {
+          kind: "tool-call",
+          payload: { toolCallId: "tc-1", toolName: "search", input: { query: "weather" } },
+        },
+        {
+          kind: "tool-result",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "search",
+            output: "Sunny",
+            isError: false,
+          },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+        { kind: "step-started", payload: { stepIndex: 1 } },
+        { kind: "text-delta", payload: { delta: "It is sunny." } },
+        { kind: "step-finished", payload: { stepIndex: 1, finishReason: "stop" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+
+      expect(messages).toHaveLength(3);
+      expect(messages[0]).toMatchObject({
+        id: "msg-1",
+        parentMessageId: null,
+        role: "assistant",
+        parts: [
+          { type: "text", text: "I'll check." },
+          {
+            type: "tool-call",
+            toolCallId: "tc-1",
+            toolName: "search",
+            input: { query: "weather" },
+          },
+        ],
+        metadata: {
+          stepFinish: { stepIndex: 0, finishReason: "tool-calls" },
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        id: "msg-2",
+        parentMessageId: "msg-1",
+        role: "tool",
+        parts: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            toolName: "search",
+            output: "Sunny",
+            isError: false,
+          },
+        ],
+      });
+      expect(messages[2]).toMatchObject({
+        id: "msg-3",
+        parentMessageId: "msg-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "It is sunny." }],
+      });
+    });
+
+    it("queues multiple early tool results until the assistant step boundary", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: { toolCallId: "tc-1", toolName: "read", input: { path: "/a.txt" } },
+        },
+        {
+          kind: "tool-call",
+          payload: { toolCallId: "tc-2", toolName: "read", input: { path: "/b.txt" } },
+        },
+        {
+          kind: "tool-result",
+          payload: { toolCallId: "tc-1", toolName: "read", output: "a", isError: false },
+        },
+        {
+          kind: "tool-result",
+          payload: { toolCallId: "tc-2", toolName: "read", output: "b", isError: false },
+        },
+        { kind: "step-finished", payload: { stepIndex: 0, finishReason: "tool-calls" } },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+
+      expect(messages.map((message) => message.role)).toEqual(["assistant", "tool", "tool"]);
+      expect(messages.map((message) => message.parentMessageId)).toEqual([null, "msg-1", "msg-2"]);
+      expect(messages[1]!.parts[0]).toMatchObject({ toolCallId: "tc-1", output: "a" });
+      expect(messages[2]!.parts[0]).toMatchObject({ toolCallId: "tc-2", output: "b" });
+    });
+
+    it("flushes queued early tool results when accumulation ends mid-step", () => {
+      const idGen = createCounterIdGenerator("msg");
+      const storedEvents = wrapEvents([
+        { kind: "step-started", payload: { stepIndex: 0 } },
+        {
+          kind: "tool-call",
+          payload: { toolCallId: "tc-1", toolName: "read", input: { path: "/a.txt" } },
+        },
+        {
+          kind: "tool-result",
+          payload: { toolCallId: "tc-1", toolName: "read", output: "a", isError: false },
+        },
+      ]);
+
+      const messages = accumulateEvents(storedEvents, idGen);
+
+      expect(messages.map((message) => message.role)).toEqual(["assistant", "tool"]);
+      expect(messages[1]).toMatchObject({
+        parentMessageId: "msg-1",
+        parts: [{ type: "tool-result", toolCallId: "tc-1", output: "a" }],
+      });
+    });
   });
 
   describe("tool metadata", () => {


### PR DESCRIPTION
## Summary
- preserve assistant transcript turn boundaries when tool results arrive before step-finished by queueing tool results until the assistant message is committed
- add PromptComponent stability/budget metadata plus PromptBuilder.buildWithDiagnostics() fingerprints for prompt-cache diagnostics
- annotate default prompt components and update prompt-builder docs/changelogs

## Testing
- bun run check
- bun run --filter '@lleverage-ai/agent-threads' test tests/ledger/accumulator.test.ts\n- bun run --filter '@lleverage-ai/agent-sdk' test tests/prompt-builder.test.ts\n- bun run --filter '@lleverage-ai/agent-threads' type-check && bun run --filter '@lleverage-ai/agent-sdk' type-check\n- pre-push hook: biome check, @lleverage-ai/agent-threads build/test, @lleverage-ai/agent-sdk test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt diagnostics and fingerprinting with per-section analysis (priority, stability, char counts); optional component budget and stability metadata; new buildWithDiagnostics() returns prompt plus diagnostics.

* **Bug Fixes**
  * Event-ordering fix: early tool-result events are queued and emitted with correct assistant step/message boundaries.

* **Documentation**
  * Updated prompt-builder docs to describe stability/budget metadata and the diagnostics workflow.

* **Tests**
  * Added tests covering diagnostics, stability defaults, budget cloning, and accumulator boundary/flush behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->