### PR TITLE
chore(release): prepare next 0.1.0 alpha releases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/agent-sdk": {
       "name": "@lleverage-ai/agent-sdk",
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ajv": "^8.17.1",
@@ -34,7 +34,7 @@
     },
     "packages/agent-threads": {
       "name": "@lleverage-ai/agent-threads",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.6",
       "devDependencies": {
         "vitest": "^4.0.18",
         "zod": "^4.3.6",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-threads/package.json
+++ b/packages/agent-threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-threads",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Event transport, replay, and durable transcripts for AI agent conversations",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump @lleverage-ai/agent-sdk to 0.1.0-alpha.4
- Bump @lleverage-ai/agent-threads to 0.1.0-alpha.6
- Update bun.lock workspace versions to match

## Validation
- bun run check
- pre-push hook: agent-threads build + tests, agent-sdk tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions: Agent SDK incremented to 0.1.0-alpha.4 and Agent Threads incremented to 0.1.0-alpha.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->