### PR TITLE
Release agent-sdk 0.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] - 2026-05-08
+
 ### Added
 
 - `agent.stream()` now forwards streamed tool input lifecycle chunks (`tool-input-start`, normalized `tool-input-delta`, and `tool-input-end`) before the final `tool-call`, allowing clients to render tool arguments as they are generated (#132)

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/agent-sdk": {
       "name": "@lleverage-ai/agent-sdk",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ajv": "^8.17.1",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump @lleverage-ai/agent-sdk to 0.1.0-alpha.5
- move Unreleased changelog entries into the 0.1.0-alpha.5 release section
- update bun.lock workspace metadata

## Test plan
- bun run check:fix
- bun run --filter '@lleverage-ai/agent-sdk' type-check
- bun run --filter '@lleverage-ai/agent-sdk' test streaming-lifecycle-events.test.ts
- pre-push: biome check . && bun run --filter '@lleverage-ai/agent-threads' build && bun run --filter '@lleverage-ai/agent-threads' test && bun run --filter '@lleverage-ai/agent-sdk' test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Version 0.1.0-alpha.5** (released 2026-05-08)

* **New Features**
  * Agent streaming and tool lifecycle behaviours
  * Hook short-circuiting support
  * Typed backend read results
  * Prompt metadata and fingerprinting

* **Bug Fixes**
  * Fixed agent-threads accumulation boundary preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->