### PR TITLE
Normalize AI SDK tool input stream chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `agent.stream()` now normalizes AI SDK v6 tool input chunks that use `id`/`delta` fields, preserving `toolName` across start/delta/end events so real provider streams expose progressive tool arguments (#132)
+
 ## [0.1.0-alpha.5] - 2026-05-08
 
 ### Added

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -3176,6 +3176,7 @@ export function createAgent(options: AgentOptions): Agent {
           // AI SDK only carries the response id on `finish-step`, not on
           // `start-step`, so `turn-start` is emitted without a messageId and
           // consumers correlate via the matching `turn-end`.
+          const activeToolInputToolNames = new Map<string, string>();
           for await (const part of response.fullStream) {
             if (part.type === "start-step") {
               // A new assistant message is beginning.
@@ -3224,12 +3225,26 @@ export function createAgent(options: AgentOptions): Agent {
                 id: typeof part.id === "string" ? part.id : undefined,
               };
             } else if (part.type === "tool-input-start") {
-              const rawPart = part as unknown as { toolCallId?: unknown; toolName?: unknown };
-              if (typeof rawPart.toolCallId === "string") {
+              const rawPart = part as unknown as {
+                id?: unknown;
+                toolCallId?: unknown;
+                toolName?: unknown;
+              };
+              const toolCallId =
+                typeof rawPart.toolCallId === "string"
+                  ? rawPart.toolCallId
+                  : typeof rawPart.id === "string"
+                    ? rawPart.id
+                    : undefined;
+              const toolName = typeof rawPart.toolName === "string" ? rawPart.toolName : undefined;
+              if (toolCallId !== undefined) {
+                if (toolName !== undefined) {
+                  activeToolInputToolNames.set(toolCallId, toolName);
+                }
                 yield {
                   type: "tool-input-start",
-                  toolCallId: rawPart.toolCallId,
-                  toolName: typeof rawPart.toolName === "string" ? rawPart.toolName : undefined,
+                  toolCallId,
+                  toolName,
                 };
               }
             } else if (
@@ -3237,6 +3252,7 @@ export function createAgent(options: AgentOptions): Agent {
               (part as { type: string }).type === "tool-call-delta"
             ) {
               const rawPart = part as unknown as {
+                id?: unknown;
                 toolCallId?: unknown;
                 toolName?: unknown;
                 inputTextDelta?: unknown;
@@ -3244,7 +3260,13 @@ export function createAgent(options: AgentOptions): Agent {
                 textDelta?: unknown;
                 delta?: unknown;
               };
-              if (typeof rawPart.toolCallId === "string") {
+              const toolCallId =
+                typeof rawPart.toolCallId === "string"
+                  ? rawPart.toolCallId
+                  : typeof rawPart.id === "string"
+                    ? rawPart.id
+                    : undefined;
+              if (toolCallId !== undefined) {
                 const inputTextDelta =
                   typeof rawPart.inputTextDelta === "string"
                     ? rawPart.inputTextDelta
@@ -3258,20 +3280,37 @@ export function createAgent(options: AgentOptions): Agent {
                 if (inputTextDelta !== undefined) {
                   yield {
                     type: "tool-input-delta",
-                    toolCallId: rawPart.toolCallId,
-                    toolName: typeof rawPart.toolName === "string" ? rawPart.toolName : undefined,
+                    toolCallId,
+                    toolName:
+                      typeof rawPart.toolName === "string"
+                        ? rawPart.toolName
+                        : activeToolInputToolNames.get(toolCallId),
                     inputTextDelta,
                   };
                 }
               }
             } else if (part.type === "tool-input-end") {
-              const rawPart = part as unknown as { toolCallId?: unknown; toolName?: unknown };
-              if (typeof rawPart.toolCallId === "string") {
+              const rawPart = part as unknown as {
+                id?: unknown;
+                toolCallId?: unknown;
+                toolName?: unknown;
+              };
+              const toolCallId =
+                typeof rawPart.toolCallId === "string"
+                  ? rawPart.toolCallId
+                  : typeof rawPart.id === "string"
+                    ? rawPart.id
+                    : undefined;
+              if (toolCallId !== undefined) {
                 yield {
                   type: "tool-input-end",
-                  toolCallId: rawPart.toolCallId,
-                  toolName: typeof rawPart.toolName === "string" ? rawPart.toolName : undefined,
+                  toolCallId,
+                  toolName:
+                    typeof rawPart.toolName === "string"
+                      ? rawPart.toolName
+                      : activeToolInputToolNames.get(toolCallId),
                 };
+                activeToolInputToolNames.delete(toolCallId);
               }
             } else if (part.type === "tool-call") {
               yield {

--- a/packages/agent-sdk/tests/streaming-lifecycle-events.test.ts
+++ b/packages/agent-sdk/tests/streaming-lifecycle-events.test.ts
@@ -261,6 +261,95 @@ describe("Stream lifecycle events", () => {
     });
   });
 
+  it("normalizes AI SDK tool input chunks that use id and delta fields", async () => {
+    const model = createMockModel();
+    const agent = createAgent({ model });
+
+    const usage = { promptTokens: 4, completionTokens: 8, totalTokens: 12 };
+    const mockStream = {
+      fullStream: (async function* () {
+        yield { type: "start-step" as const };
+        yield {
+          type: "tool-input-start" as const,
+          id: "call_1",
+          toolName: "send_user_message",
+        };
+        yield {
+          type: "tool-input-delta" as const,
+          id: "call_1",
+          delta: '{"message":"Hel',
+        };
+        yield {
+          type: "tool-input-delta" as const,
+          id: "call_1",
+          delta: 'lo"}',
+        };
+        yield {
+          type: "tool-input-end" as const,
+          id: "call_1",
+        };
+        yield {
+          type: "tool-call" as const,
+          toolCallId: "call_1",
+          toolName: "send_user_message",
+          input: { message: "Hello" },
+        };
+        yield {
+          type: "finish-step" as const,
+          response: { id: "msg_tool" },
+          finishReason: "tool-calls" as const,
+          usage,
+        };
+        yield {
+          type: "finish" as const,
+          finishReason: "tool-calls" as const,
+          totalUsage: usage,
+        };
+      })(),
+      text: Promise.resolve(""),
+      usage: Promise.resolve(usage),
+      finishReason: Promise.resolve("tool-calls" as const),
+      steps: Promise.resolve([]),
+    };
+    vi.mocked(streamText).mockReturnValue(mockStream as any);
+
+    const collected: StreamPart[] = [];
+    for await (const part of agent.stream({ prompt: "test" })) {
+      collected.push(part);
+    }
+
+    expect(collected.slice(1, 5)).toEqual([
+      {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "send_user_message",
+      },
+      {
+        type: "tool-input-delta",
+        toolCallId: "call_1",
+        toolName: "send_user_message",
+        inputTextDelta: '{"message":"Hel',
+      },
+      {
+        type: "tool-input-delta",
+        toolCallId: "call_1",
+        toolName: "send_user_message",
+        inputTextDelta: 'lo"}',
+      },
+      {
+        type: "tool-input-end",
+        toolCallId: "call_1",
+        toolName: "send_user_message",
+      },
+    ]);
+    expect(collected[5]).toEqual({
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "send_user_message",
+      input: { message: "Hello" },
+    });
+  });
+
   it("emits turn-start/turn-end without messageId when finish-step has no response id", async () => {
     const model = createMockModel();
     const agent = createAgent({ model });


### PR DESCRIPTION
## Summary
- reproduce the Lleverage alpha.5 issue with AI SDK v6 tool input chunks shaped as `{ id, delta }`
- normalize `id` to `toolCallId` for tool input start/delta/end
- track tool names from `tool-input-start` so delta/end events include `toolName` even when AI SDK omits it

## Why
Follow-up testing in Lleverage showed alpha.5 still dropped real AI SDK tool input chunks because AI SDK emits `id` and `delta`, while the SDK only accepted `toolCallId` on all parts. The new regression test fails on alpha.5 behavior and passes with this fix.

Refs #132

## Test plan
- bun run --filter '@lleverage-ai/agent-sdk' test streaming-lifecycle-events.test.ts
- bun run --filter '@lleverage-ai/agent-sdk' type-check
- bun run check:fix
- bun run --filter '@lleverage-ai/agent-sdk' test
- pre-push: biome check . && bun run --filter '@lleverage-ai/agent-threads' build && bun run --filter '@lleverage-ai/agent-threads' test && bun run --filter '@lleverage-ai/agent-sdk' test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved tool input streaming reliability by ensuring tool names persist across the complete lifecycle of tool input events, resolving inconsistencies with AI SDK v6 compatibility.

* **Tests**
  * Added comprehensive test coverage validating correct normalisation of tool input streaming events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->