### PR TITLE
chore: release agent-sdk 0.1.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.6] - 2026-05-08
+
 ### Fixed
 
 - `agent.stream()` now normalizes AI SDK v6 tool input chunks that use `id`/`delta` fields, preserving `toolName` across start/delta/end events so real provider streams expose progressive tool arguments (#132)

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/agent-sdk": {
       "name": "@lleverage-ai/agent-sdk",
-      "version": "0.1.0-alpha.5",
+      "version": "0.1.0-alpha.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ajv": "^8.17.1",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump `@lleverage-ai/agent-sdk` to `0.1.0-alpha.6`
- Move the pending changelog fix entry into the alpha.6 release section

## Testing

- [x] `bun run check`
- [x] `bun run type-check`
- [x] `bun run test`

## Docs And Changelog

- [x] Updated `CHANGELOG.md` for public behavior changes
- [x] Updated README/docs/examples where needed (not needed)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described here

## Notes

- Release tag to create after merge: `agent-sdk@0.1.0-alpha.6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed `agent.stream()` tool input handling to properly normalise input chunk shapes according to AI SDK v6 specifications. Tool names are now consistently preserved throughout the entire tool-input lifecycle (start, delta, end), and provider streams correctly expose progressive tool arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->