### PR TITLE
Release 0.1.0-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.7] - 2026-05-14
+
 ### Added
 
 - Added canonical transcript compaction summary types, an in-memory `CompactionStore`, `SummaryAwareContextBuilder`, and an `@lleverage-ai/agent-threads` ledger-backed compaction store adapter for persistent branch-aware transcript summary substitution.

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-threads/package.json
+++ b/packages/agent-threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-threads",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Event transport, replay, and durable transcripts for AI agent conversations",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump @lleverage-ai/agent-sdk to 0.1.0-alpha.7
- Bump @lleverage-ai/agent-threads to 0.1.0-alpha.7
- Move Unreleased changelog entries into the alpha.7 release section

## Test plan
- bun run check
- bun run type-check
- bun run test
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 0.1.0-alpha.7 for the Agent SDK and Agent Threads packages.
  * Updated the changelog with the new 0.1.0-alpha.7 release entry dated 14 May 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lleverage-ai/agent-sdk/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->