### PR TITLE
feat(agent-sdk): add experimental_telemetry passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional `experimental_telemetry?: TelemetrySettings` field to `GenerateOptions`, passed straight through to the underlying `generateText`/`streamText` calls at every model-invocation site in the agent loop. When a caller opts in and an OpenTelemetry tracer provider is registered, the AI SDK emits `ai.*` spans with `gen_ai.*` semantic-convention attributes for each model invocation and tool call. Pure passthrough — no behaviour change unless the caller opts in.
+
 ## [0.1.0-alpha.7] - 2026-05-14
 
 ### Added

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -2578,6 +2578,7 @@ export function createAgent(options: AgentOptions): Agent {
             abortSignal: effectiveGenOptions.signal,
             providerOptions: effectiveGenOptions.providerOptions,
             headers: effectiveGenOptions.headers,
+            experimental_telemetry: effectiveGenOptions.experimental_telemetry,
           };
 
           // Stop condition: stop when an interrupt signal was caught, OR when
@@ -2606,6 +2607,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_telemetry: initialParams.experimental_telemetry,
             experimental_context: toolExecutionContext,
           });
 
@@ -3142,6 +3144,7 @@ export function createAgent(options: AgentOptions): Agent {
             abortSignal: effectiveGenOptions.signal,
             providerOptions: effectiveGenOptions.providerOptions,
             headers: effectiveGenOptions.headers,
+            experimental_telemetry: effectiveGenOptions.experimental_telemetry,
           };
 
           // Stop condition: stop when an interrupt signal was caught, OR when
@@ -3170,6 +3173,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_telemetry: initialParams.experimental_telemetry,
             experimental_context: toolExecutionContext,
           });
 
@@ -3629,6 +3633,7 @@ export function createAgent(options: AgentOptions): Agent {
             abortSignal: effectiveGenOptions.signal,
             providerOptions: effectiveGenOptions.providerOptions,
             headers: effectiveGenOptions.headers,
+            experimental_telemetry: effectiveGenOptions.experimental_telemetry,
           };
 
           // Capture currentModel for use in the callback closure
@@ -3665,6 +3670,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_telemetry: initialParams.experimental_telemetry,
             experimental_context: toolExecutionContext,
             // Incremental checkpointing: save after each step if enabled
             onStepFinish: effectiveGenOptions.checkpointAfterToolCall
@@ -3833,6 +3839,7 @@ export function createAgent(options: AgentOptions): Agent {
                         // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                         providerOptions: requestOptions.providerOptions as any,
                         headers: requestOptions.headers,
+                        experimental_telemetry: requestOptions.experimental_telemetry,
                         experimental_context: toolExecutionContext,
                       });
                     },
@@ -4045,6 +4052,7 @@ export function createAgent(options: AgentOptions): Agent {
             abortSignal: effectiveGenOptions.signal,
             providerOptions: effectiveGenOptions.providerOptions,
             headers: effectiveGenOptions.headers,
+            experimental_telemetry: effectiveGenOptions.experimental_telemetry,
           };
 
           // Track step count for incremental checkpointing
@@ -4076,6 +4084,7 @@ export function createAgent(options: AgentOptions): Agent {
             // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
             providerOptions: initialParams.providerOptions as any,
             headers: initialParams.headers,
+            experimental_telemetry: initialParams.experimental_telemetry,
             experimental_context: toolExecutionContext,
             // Incremental checkpointing: save after each step if enabled
             onStepFinish: effectiveGenOptions.checkpointAfterToolCall
@@ -4321,6 +4330,7 @@ export function createAgent(options: AgentOptions): Agent {
                 abortSignal: effectiveGenOptions.signal,
                 providerOptions: effectiveGenOptions.providerOptions,
                 headers: effectiveGenOptions.headers,
+                experimental_telemetry: effectiveGenOptions.experimental_telemetry,
               };
 
               // Track step count for incremental checkpointing
@@ -4352,6 +4362,7 @@ export function createAgent(options: AgentOptions): Agent {
                 // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                 providerOptions: initialParams.providerOptions as any,
                 headers: initialParams.headers,
+                experimental_telemetry: initialParams.experimental_telemetry,
                 experimental_context: toolExecutionContext,
                 // Incremental checkpointing: save after each step if enabled
                 onStepFinish: effectiveGenOptions.checkpointAfterToolCall
@@ -4559,6 +4570,7 @@ export function createAgent(options: AgentOptions): Agent {
                         // biome-ignore lint/suspicious/noExplicitAny: Type cast needed for AI SDK compatibility
                         providerOptions: requestOptions.providerOptions as any,
                         headers: requestOptions.headers,
+                        experimental_telemetry: requestOptions.experimental_telemetry,
                         experimental_context: toolExecutionContext,
                       });
                     },

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -1979,11 +1979,15 @@ export interface GenerateOptions {
    * the underlying `generateText`/`streamText` calls. When enabled and an
    * OpenTelemetry tracer provider is registered (typically via
    * `@opentelemetry/sdk-node`), the AI SDK emits `ai.*` spans with full
-   * `gen_ai.*` semantic-convention attributes for every model invocation
-   * and tool call inside the agent loop.
+   * `gen_ai.*` semantic-convention attributes for each model invocation,
+   * plus `ai.toolCall` spans for tool calls executed through the SDK.
    *
    * The SDK does not enable, transform, or interpret this option — it is
    * a pure passthrough to the AI SDK.
+   *
+   * Note: `recordInputs` and `recordOutputs` default to `true`, so prompts
+   * and completions are captured unless you set them to `false` (e.g. to
+   * avoid sending sensitive content to your telemetry backend).
    *
    * @see https://ai-sdk.dev/docs/ai-sdk-core/telemetry
    *
@@ -1994,8 +1998,8 @@ export interface GenerateOptions {
    *   experimental_telemetry: {
    *     isEnabled: true,
    *     functionId: "my-agent",
-   *     recordInputs: false,
-   *     recordOutputs: false,
+   *     recordInputs: false, // omit prompts from spans
+   *     recordOutputs: false, // omit completions from spans
    *     metadata: { userId: "user_123" },
    *   },
    * });

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -13,6 +13,7 @@ import type {
   ModelMessage,
   Output,
   streamText,
+  TelemetrySettings,
   Tool,
   ToolExecutionOptions,
   ToolSet,
@@ -1972,6 +1973,35 @@ export interface GenerateOptions {
    * Useful for custom authentication or provider-specific headers.
    */
   headers?: Record<string, string>;
+
+  /**
+   * OpenTelemetry telemetry configuration, passed straight through to
+   * the underlying `generateText`/`streamText` calls. When enabled and an
+   * OpenTelemetry tracer provider is registered (typically via
+   * `@opentelemetry/sdk-node`), the AI SDK emits `ai.*` spans with full
+   * `gen_ai.*` semantic-convention attributes for every model invocation
+   * and tool call inside the agent loop.
+   *
+   * The SDK does not enable, transform, or interpret this option — it is
+   * a pure passthrough to the AI SDK.
+   *
+   * @see https://ai-sdk.dev/docs/ai-sdk-core/telemetry
+   *
+   * @example
+   * ```typescript
+   * const result = await agent.generate({
+   *   prompt: "Hello",
+   *   experimental_telemetry: {
+   *     isEnabled: true,
+   *     functionId: "my-agent",
+   *     recordInputs: false,
+   *     recordOutputs: false,
+   *     metadata: { userId: "user_123" },
+   *   },
+   * });
+   * ```
+   */
+  experimental_telemetry?: TelemetrySettings;
 
   /**
    * Callback invoked when the stream writer becomes available.


### PR DESCRIPTION
## Summary
- Add an optional `experimental_telemetry?: TelemetrySettings` field to `GenerateOptions`, slotted into the existing "AI SDK Passthrough Options" section.
- Thread it through every `generateText`/`streamText` call site in the agent loop (including follow-up streams).
- Pure passthrough — the SDK does not enable, transform, or interpret the option. No behaviour change unless a caller opts in.

When a caller opts in and registers an OpenTelemetry tracer provider globally (e.g. via `@opentelemetry/sdk-node`), the AI SDK emits `ai.*` spans with full `gen_ai.*` semantic-convention attributes for every model invocation and tool call inside the agent loop. This is the prerequisite for downstream OTel observability backends such as PostHog LLM Observability.

## Test plan
- [x] `tsc --noEmit` passes
- [x] full vitest suite passes (2187 passed, 8 skipped)
- [x] downstream verification: traces flow correctly when consumed by workflow-service with its OTel bootstrap (validated locally via packed tarball)

## Notes
- Consumed downstream by the Lleverage monorepo's workflow-service telemetry work (LLE-10170 / LLE-10171). That PR is held until this lands and is published as `alpha.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added optional OpenTelemetry telemetry integration to `GenerateOptions`, enabling observability spans for model invocations and tool calls when configured with an OpenTelemetry tracer provider. This feature is opt-in and has no impact unless explicitly enabled by the user.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lleverage-ai/agent-sdk/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->