### PR TITLE
chore: bump agent-sdk to 0.1.0-alpha.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.8] - 2026-06-01
+
 ### Added
 
 - Added an optional `experimental_telemetry?: TelemetrySettings` field to `GenerateOptions`, passed straight through to the underlying `generateText`/`streamText` calls at every model-invocation site in the agent loop. When a caller opts in and an OpenTelemetry tracer provider is registered, the AI SDK emits `ai.*` spans with `gen_ai.*` semantic-convention attributes for each model invocation and tool call. Pure passthrough — no behaviour change unless the caller opts in.

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v6",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump @lleverage-ai/agent-sdk to 0.1.0-alpha.8
- Move current changelog entry from Unreleased to 0.1.0-alpha.8

## Validation
- bun run check
- bun run --filter '@lleverage-ai/agent-sdk' type-check
- pre-push hook: bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.1.0-alpha.8 of the Agent SDK. Version information has been updated across all distribution channels and supporting documentation to reflect this release.

* **Documentation**
  * Added comprehensive release heading and documentation for version 0.1.0-alpha.8, officially released on 1 June 2026. The release notes now include a dedicated entry for this new alpha version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->