### PR TITLE
feat(prompt-builder): opt-in system-prompt cache breakpoint [LLE-10626]

### DIFF
--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -360,23 +360,6 @@ function projectMessagesForModel(
  * @see {@link https://ai-sdk.dev/providers/ai-sdk-providers/anthropic | Anthropic provider options}
  * @internal
  */
-/**
- * Report whether a model message already carries an Anthropic `cacheControl`
- * breakpoint in its provider options.
- *
- * Incoming messages may already be annotated by the caller, a checkpoint
- * restore, or a prior turn, so the conversation-breakpoint budget must account
- * for them before stamping another.
- *
- * @param message - The model message to inspect, or `undefined`.
- * @returns `true` when an Anthropic `cacheControl` breakpoint is present.
- * @internal
- */
-function hasAnthropicCacheBreakpoint(message: ModelMessage | undefined): boolean {
-  const anthropic = message?.providerOptions?.anthropic;
-  return typeof anthropic === "object" && anthropic !== null && "cacheControl" in anthropic;
-}
-
 function markLatestMessageCacheBreakpoint(
   messages: ModelMessage[],
   ttl: PromptCacheTtl,
@@ -401,6 +384,23 @@ function markLatestMessageCacheBreakpoint(
   const next = messages.slice();
   next[lastIndex] = marked;
   return next;
+}
+
+/**
+ * Report whether a model message already carries an Anthropic `cacheControl`
+ * breakpoint in its provider options.
+ *
+ * Incoming messages may already be annotated by the caller, a checkpoint
+ * restore, or a prior turn, so the conversation-breakpoint budget must account
+ * for them before stamping another.
+ *
+ * @param message - The model message to inspect, or `undefined`.
+ * @returns `true` when an Anthropic `cacheControl` breakpoint is present.
+ * @internal
+ */
+function hasAnthropicCacheBreakpoint(message: ModelMessage | undefined): boolean {
+  const anthropic = message?.providerOptions?.anthropic;
+  return typeof anthropic === "object" && anthropic !== null && "cacheControl" in anthropic;
 }
 
 /**

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { ModelMessage, Tool, ToolExecutionOptions, ToolSet } from "ai";
+import type { ModelMessage, SystemModelMessage, Tool, ToolExecutionOptions, ToolSet } from "ai";
 import {
   createUIMessageStream,
   createUIMessageStreamResponse,
@@ -59,10 +59,12 @@ import {
 } from "./observability/execution-metadata.js";
 import { createDefaultPromptBuilder } from "./prompt-builder/components.js";
 import type {
+  PromptCacheTtl,
   PromptContext,
   PromptInstructionLayer,
   PromptMemoryContext,
 } from "./prompt-builder/index.js";
+import { MAX_PROMPT_CACHE_BREAKPOINTS } from "./prompt-builder/index.js";
 import { ACCEPT_EDITS_BLOCKED_PATTERNS } from "./security/index.js";
 import { createSubagent } from "./subagents.js";
 import { TaskManager } from "./task-manager.js";
@@ -340,6 +342,44 @@ function projectMessagesForModel(
       }),
     };
   }) as ModelMessage[];
+}
+
+/**
+ * Return a copy of `messages` with the last entry annotated with an Anthropic
+ * `cacheControl` breakpoint, caching the conversation prefix up to and including
+ * the latest turn for multi-turn reuse.
+ *
+ * The original array and messages are not mutated; only the last message is
+ * shallow-cloned with merged `providerOptions`. The `anthropic` namespace is
+ * inert for other providers, so the annotation is provider-agnostic.
+ *
+ * @see https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
+ * @internal
+ */
+function markLatestMessageCacheBreakpoint(
+  messages: ModelMessage[],
+  ttl: PromptCacheTtl,
+): ModelMessage[] {
+  const lastIndex = messages.length - 1;
+  const last = messages[lastIndex];
+  if (last === undefined) {
+    return messages;
+  }
+
+  const marked: ModelMessage = {
+    ...last,
+    providerOptions: {
+      ...last.providerOptions,
+      anthropic: {
+        ...(last.providerOptions?.anthropic as Record<string, unknown> | undefined),
+        cacheControl: { type: "ephemeral", ttl },
+      },
+    },
+  };
+
+  const next = messages.slice();
+  next[lastIndex] = marked;
+  return next;
 }
 
 /**
@@ -1493,13 +1533,46 @@ export function createAgent(options: AgentOptions): Agent {
     };
   };
 
-  // Helper to get system prompt (either static or built from context)
-  const getSystemPrompt = (context: PromptContext): string | undefined => {
+  // Resolved system-prompt caching configuration (default: disabled).
+  const systemPromptCaching = options.systemPromptCaching;
+  const systemCachingEnabled = systemPromptCaching?.enabled === true && promptMode === "builder";
+  const systemCacheTtl: PromptCacheTtl = systemPromptCaching?.ttl ?? "5m";
+  // The stable system head consumes one breakpoint when caching is enabled.
+  const conversationBreakpointEnabled =
+    systemCachingEnabled &&
+    systemPromptCaching?.conversationBreakpoint === true &&
+    // Reserve one slot for the system head; only add the conversation
+    // breakpoint while we remain within the provider's breakpoint budget.
+    MAX_PROMPT_CACHE_BREAKPOINTS >= 2;
+
+  // Helper to get system prompt. Returns a plain string by default (byte-stable
+  // legacy behaviour), or an array of cache-annotated system messages when
+  // system-prompt caching is enabled and a builder is in use.
+  const getSystemPrompt = (context: PromptContext): string | SystemModelMessage[] | undefined => {
     if (promptMode === "static") {
       return options.systemPrompt;
     }
+    if (systemCachingEnabled) {
+      return promptBuilder!.buildSystemMessages(context, { cacheTtl: systemCacheTtl });
+    }
     // Build prompt using prompt builder
     return promptBuilder!.build(context);
+  };
+
+  // Apply the optional conversation-prefix cache breakpoint to the latest
+  // model message, then project messages for the active model capabilities.
+  // When the conversation breakpoint is disabled this is a transparent
+  // pass-through to {@link projectMessagesForModel}, so default behaviour is
+  // byte-for-byte unchanged.
+  const prepareModelMessages = (
+    messages: ModelMessage[],
+    capabilities: ModelInputCapabilities | undefined,
+  ): ModelMessage[] => {
+    const projected = projectMessagesForModel(messages, capabilities);
+    if (!conversationBreakpointEnabled || projected.length === 0) {
+      return projected;
+    }
+    return markLatestMessageCacheBreakpoint(projected, systemCacheTtl);
   };
 
   const responseMessagesToModelMessages = (messages: unknown[] | undefined): ModelMessage[] =>
@@ -2592,7 +2665,7 @@ export function createAgent(options: AgentOptions): Agent {
           const response = await generateText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: projectMessagesForModel(
+            messages: prepareModelMessages(
               initialParams.messages,
               toolExecutionContext.agentSdk.modelCapabilities,
             ),
@@ -3158,7 +3231,7 @@ export function createAgent(options: AgentOptions): Agent {
           const response = streamText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: projectMessagesForModel(
+            messages: prepareModelMessages(
               initialParams.messages,
               toolExecutionContext.agentSdk.modelCapabilities,
             ),
@@ -3655,7 +3728,7 @@ export function createAgent(options: AgentOptions): Agent {
           const result = streamText({
             model: modelToUse,
             system: initialParams.system,
-            messages: projectMessagesForModel(
+            messages: prepareModelMessages(
               initialParams.messages,
               toolExecutionContext.agentSdk.modelCapabilities,
             ),
@@ -3825,7 +3898,7 @@ export function createAgent(options: AgentOptions): Agent {
                       return streamText({
                         model: currentModel,
                         system: getSystemPrompt(followUpPromptContext),
-                        messages: projectMessagesForModel(
+                        messages: prepareModelMessages(
                           followUpMessages,
                           toolExecutionContext.agentSdk.modelCapabilities,
                         ),
@@ -4069,7 +4142,7 @@ export function createAgent(options: AgentOptions): Agent {
           const result = streamText({
             model: retryState.currentModel,
             system: initialParams.system,
-            messages: projectMessagesForModel(
+            messages: prepareModelMessages(
               initialParams.messages,
               toolExecutionContext.agentSdk.modelCapabilities,
             ),
@@ -4347,7 +4420,7 @@ export function createAgent(options: AgentOptions): Agent {
               const result = streamText({
                 model: modelToUse,
                 system: initialParams.system,
-                messages: projectMessagesForModel(
+                messages: prepareModelMessages(
                   initialParams.messages,
                   toolExecutionContext.agentSdk.modelCapabilities,
                 ),
@@ -4556,7 +4629,7 @@ export function createAgent(options: AgentOptions): Agent {
                       return streamText({
                         model: currentModel,
                         system: getSystemPrompt(followUpPromptContext),
-                        messages: projectMessagesForModel(
+                        messages: prepareModelMessages(
                           followUpMessages,
                           toolExecutionContext.agentSdk.modelCapabilities,
                         ),

--- a/packages/agent-sdk/src/agent.ts
+++ b/packages/agent-sdk/src/agent.ts
@@ -353,9 +353,30 @@ function projectMessagesForModel(
  * shallow-cloned with merged `providerOptions`. The `anthropic` namespace is
  * inert for other providers, so the annotation is provider-agnostic.
  *
- * @see https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
+ * @param messages - The model messages to annotate.
+ * @param ttl - The Anthropic prompt-cache time-to-live to apply.
+ * @returns A copied message array with the latest message annotated, or the
+ * original array when it is empty.
+ * @see {@link https://ai-sdk.dev/providers/ai-sdk-providers/anthropic | Anthropic provider options}
  * @internal
  */
+/**
+ * Report whether a model message already carries an Anthropic `cacheControl`
+ * breakpoint in its provider options.
+ *
+ * Incoming messages may already be annotated by the caller, a checkpoint
+ * restore, or a prior turn, so the conversation-breakpoint budget must account
+ * for them before stamping another.
+ *
+ * @param message - The model message to inspect, or `undefined`.
+ * @returns `true` when an Anthropic `cacheControl` breakpoint is present.
+ * @internal
+ */
+function hasAnthropicCacheBreakpoint(message: ModelMessage | undefined): boolean {
+  const anthropic = message?.providerOptions?.anthropic;
+  return typeof anthropic === "object" && anthropic !== null && "cacheControl" in anthropic;
+}
+
 function markLatestMessageCacheBreakpoint(
   messages: ModelMessage[],
   ttl: PromptCacheTtl,
@@ -1537,12 +1558,14 @@ export function createAgent(options: AgentOptions): Agent {
   const systemPromptCaching = options.systemPromptCaching;
   const systemCachingEnabled = systemPromptCaching?.enabled === true && promptMode === "builder";
   const systemCacheTtl: PromptCacheTtl = systemPromptCaching?.ttl ?? "5m";
-  // The stable system head consumes one breakpoint when caching is enabled.
+  // Whether the conversation breakpoint feature is requested. The stable system
+  // head already consumes one breakpoint, so the provider budget must allow at
+  // least two for this to ever apply. The per-request budget (which also counts
+  // breakpoints already present on incoming messages) is enforced in
+  // {@link prepareModelMessages} before any breakpoint is actually stamped.
   const conversationBreakpointEnabled =
     systemCachingEnabled &&
     systemPromptCaching?.conversationBreakpoint === true &&
-    // Reserve one slot for the system head; only add the conversation
-    // breakpoint while we remain within the provider's breakpoint budget.
     MAX_PROMPT_CACHE_BREAKPOINTS >= 2;
 
   // Helper to get system prompt. Returns a plain string by default (byte-stable
@@ -1559,17 +1582,42 @@ export function createAgent(options: AgentOptions): Agent {
     return promptBuilder!.build(context);
   };
 
-  // Apply the optional conversation-prefix cache breakpoint to the latest
-  // model message, then project messages for the active model capabilities.
+  // Project messages for the active model capabilities first, then apply the
+  // optional conversation-prefix cache breakpoint to the latest projected
+  // message. Projection shallow-clones messages, so annotating after projection
+  // guarantees the breakpoint lands on the message that is actually sent.
+  //
   // When the conversation breakpoint is disabled this is a transparent
   // pass-through to {@link projectMessagesForModel}, so default behaviour is
   // byte-for-byte unchanged.
+  //
+  // Anthropic permits at most {@link MAX_PROMPT_CACHE_BREAKPOINTS} breakpoints
+  // per request across tools, system, and messages. Incoming messages may
+  // already carry caller- or checkpoint-supplied `cacheControl` breakpoints, so
+  // the latest message is only stamped when doing so keeps the total within the
+  // provider budget and the latest message is not already marked (avoiding a
+  // double mark on the same target). When the gateway's `caching: 'auto'`
+  // provider option is also active it inserts breakpoints server-side that are
+  // not visible here; callers must therefore enable exactly one strategy. See
+  // {@link SystemPromptCachingOptions} for the documented precedence.
   const prepareModelMessages = (
     messages: ModelMessage[],
     capabilities: ModelInputCapabilities | undefined,
   ): ModelMessage[] => {
     const projected = projectMessagesForModel(messages, capabilities);
     if (!conversationBreakpointEnabled || projected.length === 0) {
+      return projected;
+    }
+    if (hasAnthropicCacheBreakpoint(projected.at(-1))) {
+      return projected;
+    }
+    const existingMessageBreakpoints = projected.reduce(
+      (count, message) => (hasAnthropicCacheBreakpoint(message) ? count + 1 : count),
+      0,
+    );
+    // The stable system head reserves one breakpoint while caching is enabled.
+    const reservedSystemBreakpoints = systemCachingEnabled ? 1 : 0;
+    if (reservedSystemBreakpoints + existingMessageBreakpoints + 1 > MAX_PROMPT_CACHE_BREAKPOINTS) {
       return projected;
     }
     return markLatestMessageCacheBreakpoint(projected, systemCacheTtl);

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -322,13 +322,16 @@ export {
 } from "./mcp/index.js";
 // Prompt Builder types
 export type {
+  BuildSystemMessagesOptions,
   PromptBuildResult,
+  PromptCacheTtl,
   PromptComponent,
   PromptComponentBudget,
   PromptComponentStability,
   PromptContext,
   PromptSectionDiagnostics,
 } from "./prompt-builder/index.js";
+export { MAX_PROMPT_CACHE_BREAKPOINTS } from "./prompt-builder/index.js";
 export type {
   PromptInstructionLayer,
   PromptLoadedSkill,
@@ -768,6 +771,7 @@ export type {
   SubagentOptions,
   SubagentStartInput,
   SubagentStopInput,
+  SystemPromptCachingOptions,
   TaskToolOptions,
   Tool,
   ToolCallResult,

--- a/packages/agent-sdk/src/prompt-builder/index.ts
+++ b/packages/agent-sdk/src/prompt-builder/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { ModelMessage } from "ai";
+import type { ModelMessage, SystemModelMessage } from "ai";
 import type { AgentState } from "../backends/state.js";
 import type { PermissionMode } from "../types.js";
 
@@ -362,6 +362,65 @@ export interface PromptBuildResult {
   sections: PromptSectionDiagnostics[];
 }
 
+/**
+ * Anthropic prompt-cache time-to-live for a cache breakpoint.
+ *
+ * `"5m"` is the provider default (a five-minute ephemeral cache); `"1h"` opts
+ * into the extended one-hour cache. Mirrors the Anthropic provider's
+ * `cacheControl.ttl` values exactly.
+ *
+ * @see https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching
+ * @category Types
+ */
+export type PromptCacheTtl = "5m" | "1h";
+
+/**
+ * The maximum number of Anthropic `cache_control` breakpoints permitted in a
+ * single request (tools + system + messages combined). The provider returns a
+ * 400 error if a fifth explicit breakpoint is supplied.
+ *
+ * @see https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching
+ * @category Constants
+ */
+export const MAX_PROMPT_CACHE_BREAKPOINTS = 4;
+
+/**
+ * Options for {@link PromptBuilder.buildSystemMessages}.
+ *
+ * @category Context
+ */
+export interface BuildSystemMessagesOptions {
+  /**
+   * When provided, the stable head system message is annotated with an
+   * Anthropic `cacheControl` breakpoint of this time-to-live. When omitted,
+   * no breakpoint is emitted and the split is purely structural.
+   *
+   * The `anthropic` provider namespace is inert for non-Anthropic providers, so
+   * this annotation is safe to emit regardless of the model in use.
+   */
+  cacheTtl?: PromptCacheTtl;
+}
+
+/**
+ * Build an Anthropic `cacheControl` provider-options object for a system block.
+ *
+ * The shape matches the Vercel AI SDK Anthropic provider
+ * (`providerOptions.anthropic.cacheControl = { type: "ephemeral", ttl? }`).
+ *
+ * @see https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
+ * @internal
+ */
+function buildCacheControlProviderOptions(ttl: PromptCacheTtl): SystemModelMessage["providerOptions"] {
+  return {
+    anthropic: {
+      cacheControl: {
+        type: "ephemeral",
+        ttl,
+      },
+    },
+  };
+}
+
 function fingerprintText(text: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < text.length; i += 1) {
@@ -553,6 +612,93 @@ export class PromptBuilder {
         charCount: text.length,
       })),
     };
+  }
+
+  /**
+   * Build the system prompt as an array of system messages split at the
+   * stability boundary, for provider prompt caching.
+   *
+   * Sections are rendered in the same priority order as {@link build}, then
+   * partitioned into a **stable head** and a **dynamic tail**:
+   *
+   * - The stable head is the maximal leading run of `static` sections (in
+   *   render order). It is the byte-stable prefix that is safe to cache.
+   * - The dynamic tail is every remaining section, including any `static`
+   *   section that happens to render after a `dynamic` one. Such a section
+   *   cannot belong to a byte-stable prefix (the dynamic section before it has
+   *   already broken exact-prefix matching), so it correctly falls into the
+   *   tail rather than poisoning the cached head.
+   *
+   * Concatenating the two messages' content with the same `"\n\n"` joiner that
+   * {@link build} uses reproduces the exact string {@link build} returns, so the
+   * array form is byte-faithful to the string form.
+   *
+   * When {@link BuildSystemMessagesOptions.cacheTtl} is supplied, the stable
+   * head carries an Anthropic `cacheControl` breakpoint
+   * (`providerOptions.anthropic.cacheControl = { type: "ephemeral", ttl }`). The
+   * `anthropic` namespace is inert for other providers, so the breakpoint is a
+   * no-op there and the array remains provider-agnostic.
+   *
+   * At most one breakpoint is placed here (the stable-head boundary). When no
+   * stable head exists (the first rendered section is `dynamic`) a single
+   * unmarked system message is returned, mirroring {@link build} with no
+   * cacheable prefix.
+   *
+   * @param context - The context to pass to components.
+   * @param options - Optional cache-control configuration.
+   * @returns The system prompt as one or two {@link SystemModelMessage} entries.
+   * @throws {Error} When a component condition or render callback throws.
+   *
+   * @example
+   * ```typescript
+   * const system = builder.buildSystemMessages(context, { cacheTtl: "5m" });
+   * await streamText({ model, system, messages });
+   * ```
+   */
+  buildSystemMessages(
+    context: PromptContext,
+    options: BuildSystemMessagesOptions = {},
+  ): SystemModelMessage[] {
+    const renderedSections = this.renderSections(context);
+
+    if (renderedSections.length === 0) {
+      return [];
+    }
+
+    // The stable head is the maximal leading run of static sections.
+    let boundaryIndex = 0;
+    while (
+      boundaryIndex < renderedSections.length &&
+      (renderedSections[boundaryIndex]!.component.stability ?? "dynamic") === "static"
+    ) {
+      boundaryIndex += 1;
+    }
+
+    const join = (sections: Array<{ text: string }>): string =>
+      sections.map(({ text }) => text).join("\n\n");
+
+    const stableSections = renderedSections.slice(0, boundaryIndex);
+    const dynamicSections = renderedSections.slice(boundaryIndex);
+
+    // No stable prefix: a single unmarked system message (no cacheable head).
+    if (stableSections.length === 0) {
+      return [{ role: "system", content: join(dynamicSections) }];
+    }
+
+    const stableHead: SystemModelMessage = {
+      role: "system",
+      content: join(stableSections),
+      ...(options.cacheTtl !== undefined
+        ? { providerOptions: buildCacheControlProviderOptions(options.cacheTtl) }
+        : {}),
+    };
+
+    // No dynamic tail: only the stable head (still a valid array form).
+    if (dynamicSections.length === 0) {
+      return [stableHead];
+    }
+
+    return [stableHead, { role: "system", content: join(dynamicSections) }];
   }
 
   /**

--- a/packages/agent-sdk/src/prompt-builder/index.ts
+++ b/packages/agent-sdk/src/prompt-builder/index.ts
@@ -380,7 +380,7 @@ export type PromptCacheTtl = "5m" | "1h";
  * 400 error if a fifth explicit breakpoint is supplied.
  *
  * @see https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching
- * @category Constants
+ * @category Types
  */
 export const MAX_PROMPT_CACHE_BREAKPOINTS = 4;
 
@@ -646,7 +646,9 @@ export class PromptBuilder {
    *
    * @param context - The context to pass to components.
    * @param options - Optional cache-control configuration.
-   * @returns The system prompt as one or two {@link SystemModelMessage} entries.
+   * @returns The system prompt as zero, one, or two {@link SystemModelMessage}
+   * entries. An empty array is returned when no sections render (mirroring
+   * {@link build} producing an empty string).
    * @throws {Error} When a component condition or render callback throws.
    *
    * @example

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -373,6 +373,13 @@ export type AgentUIMessage = UIMessage<AgentDataTypes>;
  * unset) the agent emits the system prompt as a single string exactly as
  * before.
  *
+ * Mutually exclusive with the Vercel AI Gateway's automatic caching
+ * (`providerOptions.gateway.caching: 'auto'`). The gateway inserts breakpoints
+ * server-side that are not visible to this SDK, so enabling both strategies can
+ * double-insert breakpoints and exceed the provider's four-breakpoint limit.
+ * Choose exactly one: this explicit, deterministic placement, or the gateway's
+ * automatic placement.
+ *
  * @see {@link AgentOptions.systemPromptCaching}
  * @category Agent
  */
@@ -618,7 +625,9 @@ export interface AgentOptions {
    * inert for other providers, so this is safe for any model.
    *
    * Static `systemPrompt` strings are not split (there is no stability metadata
-   * to split on), so this option only takes effect with a builder.
+   * to split on), so the structured system-message split only takes effect with
+   * a builder. The latest-message breakpoint is governed separately by
+   * {@link SystemPromptCachingOptions.conversationBreakpoint}.
    *
    * @example
    * ```typescript

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -366,6 +366,47 @@ export type AgentUIMessage = UIMessage<AgentDataTypes>;
 // =============================================================================
 
 /**
+ * Opt-in configuration for structured-block system emission with provider
+ * prompt-cache breakpoints.
+ *
+ * Additive and backward compatible: with `enabled: false` (or the whole object
+ * unset) the agent emits the system prompt as a single string exactly as
+ * before.
+ *
+ * @see {@link AgentOptions.systemPromptCaching}
+ * @category Agent
+ */
+export interface SystemPromptCachingOptions {
+  /**
+   * Whether to emit the system prompt as cache-annotated structured blocks.
+   *
+   * @defaultValue false
+   */
+  enabled: boolean;
+
+  /**
+   * Time-to-live for the cache breakpoint placed on the stable head.
+   *
+   * `"5m"` is the provider default; `"1h"` opts into the extended cache.
+   *
+   * @defaultValue "5m"
+   */
+  ttl?: import("./prompt-builder/index.js").PromptCacheTtl;
+
+  /**
+   * When `true`, also place a cache breakpoint on the latest conversation turn
+   * (the last model message), in addition to the stable system head. This
+   * caches the conversation prefix for multi-turn reuse.
+   *
+   * The total number of breakpoints is capped at four (the provider limit);
+   * the conversation breakpoint is only added while a slot remains.
+   *
+   * @defaultValue false
+   */
+  conversationBreakpoint?: boolean;
+}
+
+/**
  * Configuration options for creating an agent.
  *
  * @example
@@ -561,6 +602,36 @@ export interface AgentOptions {
    * @defaultValue undefined (uses default builder)
    */
   promptBuilder?: import("./prompt-builder/index.js").PromptBuilder;
+
+  /**
+   * Opt-in structured-block system emission with provider prompt-cache
+   * breakpoints.
+   *
+   * When unset or `enabled: false` (the default), the agent emits the system
+   * prompt as a single string exactly as before, so existing behaviour is
+   * byte-for-byte unchanged.
+   *
+   * When `enabled: true` **and** a {@link promptBuilder} is in use, the agent
+   * emits the system prompt as an array of system messages split at the
+   * builder's stability boundary, and annotates the stable head with an
+   * Anthropic `cacheControl` breakpoint. The `anthropic` provider namespace is
+   * inert for other providers, so this is safe for any model.
+   *
+   * Static `systemPrompt` strings are not split (there is no stability metadata
+   * to split on), so this option only takes effect with a builder.
+   *
+   * @example
+   * ```typescript
+   * const agent = createAgent({
+   *   model,
+   *   systemPromptCaching: { enabled: true, ttl: "5m", conversationBreakpoint: true },
+   * });
+   * ```
+   *
+   * @see {@link SystemPromptCachingOptions}
+   * @defaultValue undefined (string system, no caching)
+   */
+  systemPromptCaching?: SystemPromptCachingOptions;
 
   /**
    * Whether the host application exposes persistent memory to the agent.

--- a/packages/agent-sdk/tests/agent-system-prompt-caching.test.ts
+++ b/packages/agent-sdk/tests/agent-system-prompt-caching.test.ts
@@ -4,7 +4,9 @@
  * Verifies: backward-compatible string mode when disabled; structured-block
  * array emission with a cacheControl breakpoint when enabled; ttl honoured;
  * conversationBreakpoint adds a second breakpoint within the provider budget;
- * and that only the `anthropic` provider namespace is touched (provider-agnostic).
+ * the budget guard refuses to exceed the four-breakpoint limit or double-mark a
+ * message that already carries a breakpoint; and that only the `anthropic`
+ * provider namespace is touched (provider-agnostic).
  */
 
 import type { SystemModelMessage } from "ai";
@@ -217,6 +219,112 @@ describe("agent system-prompt caching", () => {
       const last = messages[messages.length - 1];
       expect(hasAnthropicCacheBreakpoint(last?.providerOptions)).toBe(true);
 
+      expect(systemBreakpoints + messageBreakpoints).toBeLessThanOrEqual(4);
+    });
+
+    it("does not exceed the provider budget when incoming messages already carry breakpoints", async () => {
+      // System head reserves one breakpoint. Three incoming messages already
+      // carrying breakpoints plus the head fill the four-breakpoint budget, so
+      // the latest message must NOT be stamped (stamping would make five).
+      const markedOptions = {
+        anthropic: { cacheControl: { type: "ephemeral" as const, ttl: "5m" as const } },
+      };
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, conversationBreakpoint: true },
+      });
+
+      await agent.generate({
+        messages: [
+          { role: "user", content: "one", providerOptions: markedOptions },
+          { role: "assistant", content: "two", providerOptions: markedOptions },
+          { role: "user", content: "three", providerOptions: markedOptions },
+        ],
+      });
+
+      const args = capturedCallArgs();
+      const system = args.system as SystemModelMessage[];
+      const messages = args.messages as Array<{ providerOptions?: unknown }>;
+
+      const systemBreakpoints = system.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+      const messageBreakpoints = messages.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+
+      // The three pre-existing breakpoints are preserved, none added.
+      expect(systemBreakpoints).toBe(1);
+      expect(messageBreakpoints).toBe(3);
+      expect(systemBreakpoints + messageBreakpoints).toBeLessThanOrEqual(4);
+    });
+
+    it("does not double-mark a latest message that already carries a breakpoint", async () => {
+      const markedOptions = {
+        anthropic: { cacheControl: { type: "ephemeral" as const, ttl: "1h" as const } },
+      };
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, conversationBreakpoint: true },
+      });
+
+      await agent.generate({
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "marked", providerOptions: markedOptions },
+        ],
+      });
+
+      const messages = capturedCallArgs().messages as Array<{
+        providerOptions?: { anthropic?: { cacheControl?: { ttl?: string } } };
+      }>;
+      const last = messages[messages.length - 1];
+
+      // The latest message keeps its original 1h breakpoint, not overwritten.
+      expect(hasAnthropicCacheBreakpoint(last?.providerOptions)).toBe(true);
+      expect(last?.providerOptions?.anthropic?.cacheControl?.ttl).toBe("1h");
+      const messageBreakpoints = messages.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+      expect(messageBreakpoints).toBe(1);
+    });
+
+    it("stamps the latest message when budget allows alongside one pre-existing breakpoint", async () => {
+      const markedOptions = {
+        anthropic: { cacheControl: { type: "ephemeral" as const, ttl: "5m" as const } },
+      };
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, conversationBreakpoint: true },
+      });
+
+      await agent.generate({
+        messages: [
+          { role: "user", content: "marked", providerOptions: markedOptions },
+          { role: "assistant", content: "tail" },
+        ],
+      });
+
+      const args = capturedCallArgs();
+      const system = args.system as SystemModelMessage[];
+      const messages = args.messages as Array<{ providerOptions?: unknown }>;
+
+      const systemBreakpoints = system.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+      const messageBreakpoints = messages.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+
+      // Head (1) + pre-existing (1) + newly stamped latest (1) = 3 <= 4.
+      expect(systemBreakpoints).toBe(1);
+      expect(messageBreakpoints).toBe(2);
+      expect(hasAnthropicCacheBreakpoint(messages[messages.length - 1]?.providerOptions)).toBe(
+        true,
+      );
       expect(systemBreakpoints + messageBreakpoints).toBeLessThanOrEqual(4);
     });
 

--- a/packages/agent-sdk/tests/agent-system-prompt-caching.test.ts
+++ b/packages/agent-sdk/tests/agent-system-prompt-caching.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Agent-level tests for opt-in system-prompt caching (LLE-10626).
+ *
+ * Verifies: backward-compatible string mode when disabled; structured-block
+ * array emission with a cacheControl breakpoint when enabled; ttl honoured;
+ * conversationBreakpoint adds a second breakpoint within the provider budget;
+ * and that only the `anthropic` provider namespace is touched (provider-agnostic).
+ */
+
+import type { SystemModelMessage } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createAgent, PromptBuilder } from "../src/index.js";
+import { createMockModel, resetMocks } from "./setup.js";
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: vi.fn(),
+    streamText: vi.fn(),
+  };
+});
+
+import { generateText } from "ai";
+
+const GENERATE_RESULT = {
+  text: "ok",
+  steps: [],
+  toolCalls: [],
+  toolResults: [],
+  finishReason: "stop",
+  usage: {
+    inputTokens: 10,
+    outputTokens: 20,
+    inputTokenDetails: {},
+    outputTokenDetails: {},
+  },
+  response: { id: "id", timestamp: new Date(), modelId: "mock-model", messages: [] },
+  request: {},
+  warnings: [],
+  providerMetadata: undefined,
+  files: [],
+  sources: [],
+  reasoning: [],
+  reasoningText: undefined,
+  content: [],
+} as never;
+
+/**
+ * A small builder with one static head and one dynamic tail so the stability
+ * split is deterministic and independent of the default component set.
+ */
+function makeBuilder(): PromptBuilder {
+  return new PromptBuilder().registerMany([
+    { name: "identity", priority: 100, stability: "static", render: () => "IDENTITY" },
+    { name: "context", priority: 80, stability: "dynamic", render: () => "CONTEXT" },
+  ]);
+}
+
+function capturedCallArgs(): Record<string, unknown> {
+  const mock = vi.mocked(generateText);
+  expect(mock).toHaveBeenCalledTimes(1);
+  return mock.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+function hasAnthropicCacheBreakpoint(providerOptions: unknown): boolean {
+  const anthropic = (providerOptions as { anthropic?: { cacheControl?: unknown } } | undefined)
+    ?.anthropic;
+  return anthropic?.cacheControl !== undefined;
+}
+
+describe("agent system-prompt caching", () => {
+  beforeEach(() => {
+    resetMocks();
+    vi.clearAllMocks();
+    vi.mocked(generateText).mockResolvedValue(GENERATE_RESULT);
+  });
+
+  describe("disabled (default) — backward compatibility", () => {
+    it("passes the system prompt as a plain string when caching is unset", async () => {
+      const agent = createAgent({ model: createMockModel(), promptBuilder: makeBuilder() });
+
+      await agent.generate({ prompt: "hi" });
+
+      const args = capturedCallArgs();
+      expect(typeof args.system).toBe("string");
+      expect(args.system).toBe("IDENTITY\n\nCONTEXT");
+    });
+
+    it("is byte-identical to the builder's build() output and to the array concatenation", async () => {
+      const builder = makeBuilder();
+      const agent = createAgent({ model: createMockModel(), promptBuilder: builder });
+
+      await agent.generate({ prompt: "hi" });
+
+      const stringSystem = capturedCallArgs().system as string;
+      expect(stringSystem).toBe(builder.build({ memoryAvailable: false }));
+    });
+
+    it("does not annotate any message with a cache breakpoint when disabled", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: false },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const messages = capturedCallArgs().messages as Array<{ providerOptions?: unknown }>;
+      for (const message of messages) {
+        expect(hasAnthropicCacheBreakpoint(message.providerOptions)).toBe(false);
+      }
+    });
+  });
+
+  describe("enabled — structured-block emission", () => {
+    it("emits the system as an array of system messages split at the stability boundary", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const system = capturedCallArgs().system as SystemModelMessage[];
+      expect(Array.isArray(system)).toBe(true);
+      expect(system).toHaveLength(2);
+      expect(system[0]?.content).toBe("IDENTITY");
+      expect(system[1]?.content).toBe("CONTEXT");
+    });
+
+    it("marks the stable head with a cacheControl breakpoint and defaults ttl to 5m", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const system = capturedCallArgs().system as SystemModelMessage[];
+      expect(system[0]?.providerOptions?.anthropic).toMatchObject({
+        cacheControl: { type: "ephemeral", ttl: "5m" },
+      });
+      expect(system[1]?.providerOptions).toBeUndefined();
+    });
+
+    it("honours an explicit 1h ttl", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, ttl: "1h" },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const system = capturedCallArgs().system as SystemModelMessage[];
+      expect(system[0]?.providerOptions?.anthropic).toMatchObject({
+        cacheControl: { type: "ephemeral", ttl: "1h" },
+      });
+    });
+
+    it("only sets the anthropic namespace, leaving the system provider-agnostic", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const system = capturedCallArgs().system as SystemModelMessage[];
+      const namespaces = Object.keys(system[0]?.providerOptions ?? {});
+      expect(namespaces).toEqual(["anthropic"]);
+    });
+
+    it("leaves a static systemPrompt string unaffected (split only applies to builders)", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        systemPrompt: "STATIC SYSTEM",
+        systemPromptCaching: { enabled: true },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const args = capturedCallArgs();
+      expect(args.system).toBe("STATIC SYSTEM");
+    });
+  });
+
+  describe("conversationBreakpoint", () => {
+    it("adds a second breakpoint on the latest message, total breakpoints <= 4", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, conversationBreakpoint: true },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const args = capturedCallArgs();
+      const system = args.system as SystemModelMessage[];
+      const messages = args.messages as Array<{ providerOptions?: unknown }>;
+
+      const systemBreakpoints = system.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+      const messageBreakpoints = messages.filter((m) =>
+        hasAnthropicCacheBreakpoint(m.providerOptions),
+      ).length;
+
+      expect(systemBreakpoints).toBe(1);
+      expect(messageBreakpoints).toBe(1);
+
+      // Only the LATEST message carries the breakpoint.
+      const last = messages[messages.length - 1];
+      expect(hasAnthropicCacheBreakpoint(last?.providerOptions)).toBe(true);
+
+      expect(systemBreakpoints + messageBreakpoints).toBeLessThanOrEqual(4);
+    });
+
+    it("does not annotate any message when conversationBreakpoint is false", async () => {
+      const agent = createAgent({
+        model: createMockModel(),
+        promptBuilder: makeBuilder(),
+        systemPromptCaching: { enabled: true, conversationBreakpoint: false },
+      });
+
+      await agent.generate({ prompt: "hi" });
+
+      const messages = capturedCallArgs().messages as Array<{ providerOptions?: unknown }>;
+      for (const message of messages) {
+        expect(hasAnthropicCacheBreakpoint(message.providerOptions)).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/agent-sdk/tests/prompt-builder-system-messages.test.ts
+++ b/packages/agent-sdk/tests/prompt-builder-system-messages.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for PromptBuilder.buildSystemMessages — structured-block system
+ * emission with an Anthropic cache_control breakpoint at the stability
+ * boundary (LLE-10626).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PromptComponent } from "../src/prompt-builder/index.js";
+import { MAX_PROMPT_CACHE_BREAKPOINTS, PromptBuilder } from "../src/prompt-builder/index.js";
+
+/**
+ * Builder with a deterministic mix of static and dynamic sections in a known
+ * priority order: two static heads, then two dynamic tails.
+ */
+function makeMixedBuilder(): PromptBuilder {
+  const components: PromptComponent[] = [
+    { name: "identity", priority: 100, stability: "static", render: () => "IDENTITY" },
+    { name: "policy", priority: 90, stability: "static", render: () => "POLICY" },
+    { name: "context", priority: 80, stability: "dynamic", render: () => "CONTEXT" },
+    { name: "recall", priority: 70, stability: "dynamic", render: () => "RECALL" },
+  ];
+  return new PromptBuilder().registerMany(components);
+}
+
+describe("PromptBuilder.buildSystemMessages", () => {
+  describe("stability boundary split", () => {
+    it("splits at the first dynamic section into a stable head and dynamic tail", () => {
+      const builder = makeMixedBuilder();
+
+      const messages = builder.buildSystemMessages({});
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]?.role).toBe("system");
+      expect(messages[0]?.content).toBe("IDENTITY\n\nPOLICY");
+      expect(messages[1]?.role).toBe("system");
+      expect(messages[1]?.content).toBe("CONTEXT\n\nRECALL");
+    });
+
+    it("treats a static section that renders after a dynamic one as part of the tail", () => {
+      // A static section is positioned (by priority) AFTER a dynamic one; it
+      // cannot be in a byte-stable prefix, so it must fall into the tail.
+      const builder = new PromptBuilder().registerMany([
+        { name: "identity", priority: 100, stability: "static", render: () => "IDENTITY" },
+        { name: "context", priority: 90, stability: "dynamic", render: () => "CONTEXT" },
+        { name: "late-static", priority: 80, stability: "static", render: () => "LATE" },
+      ]);
+
+      const messages = builder.buildSystemMessages({});
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]?.content).toBe("IDENTITY");
+      expect(messages[1]?.content).toBe("CONTEXT\n\nLATE");
+    });
+
+    it("returns a single unmarked message when the first section is dynamic (no stable head)", () => {
+      const builder = new PromptBuilder().registerMany([
+        { name: "context", priority: 100, stability: "dynamic", render: () => "CONTEXT" },
+        { name: "recall", priority: 90, stability: "dynamic", render: () => "RECALL" },
+      ]);
+
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "5m" });
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.content).toBe("CONTEXT\n\nRECALL");
+      expect(messages[0]?.providerOptions).toBeUndefined();
+    });
+
+    it("returns only the stable head when there is no dynamic tail", () => {
+      const builder = new PromptBuilder().registerMany([
+        { name: "identity", priority: 100, stability: "static", render: () => "IDENTITY" },
+        { name: "policy", priority: 90, stability: "static", render: () => "POLICY" },
+      ]);
+
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "5m" });
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.content).toBe("IDENTITY\n\nPOLICY");
+      expect(messages[0]?.providerOptions?.anthropic).toMatchObject({
+        cacheControl: { type: "ephemeral", ttl: "5m" },
+      });
+    });
+
+    it("returns an empty array when no sections render", () => {
+      const builder = new PromptBuilder().register({
+        name: "empty",
+        stability: "static",
+        render: () => "",
+      });
+
+      expect(builder.buildSystemMessages({})).toEqual([]);
+    });
+
+    it("classifies sections with no explicit stability as dynamic", () => {
+      const builder = new PromptBuilder().registerMany([
+        { name: "head", priority: 100, stability: "static", render: () => "HEAD" },
+        // No stability => defaults to dynamic => boundary.
+        { name: "rest", priority: 90, render: () => "REST" },
+      ]);
+
+      const messages = builder.buildSystemMessages({});
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]?.content).toBe("HEAD");
+      expect(messages[1]?.content).toBe("REST");
+    });
+  });
+
+  describe("cacheControl on the stable head", () => {
+    it("marks the stable head with an ephemeral cacheControl breakpoint", () => {
+      const builder = makeMixedBuilder();
+
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "5m" });
+
+      expect(messages[0]?.providerOptions?.anthropic).toMatchObject({
+        cacheControl: { type: "ephemeral", ttl: "5m" },
+      });
+      // The dynamic tail never carries a breakpoint.
+      expect(messages[1]?.providerOptions).toBeUndefined();
+    });
+
+    it("honours the 1h ttl", () => {
+      const builder = makeMixedBuilder();
+
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "1h" });
+
+      expect(messages[0]?.providerOptions?.anthropic).toMatchObject({
+        cacheControl: { type: "ephemeral", ttl: "1h" },
+      });
+    });
+
+    it("emits no breakpoint when cacheTtl is omitted (purely structural split)", () => {
+      const builder = makeMixedBuilder();
+
+      const messages = builder.buildSystemMessages({});
+
+      expect(messages[0]?.providerOptions).toBeUndefined();
+      expect(messages[1]?.providerOptions).toBeUndefined();
+    });
+
+    it("places at most one breakpoint, staying within the provider budget", () => {
+      const builder = makeMixedBuilder();
+
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "5m" });
+
+      const breakpoints = messages.filter(
+        (m) =>
+          (m.providerOptions?.anthropic as { cacheControl?: unknown } | undefined)?.cacheControl !==
+          undefined,
+      );
+      expect(breakpoints).toHaveLength(1);
+      expect(breakpoints.length).toBeLessThanOrEqual(MAX_PROMPT_CACHE_BREAKPOINTS);
+    });
+  });
+
+  describe("byte-faithfulness to build()", () => {
+    it("concatenated message content reproduces the build() string exactly", () => {
+      const builder = makeMixedBuilder();
+
+      const stringForm = builder.build({});
+      const messages = builder.buildSystemMessages({}, { cacheTtl: "1h" });
+      const concatenated = messages.map((m) => m.content).join("\n\n");
+
+      expect(concatenated).toBe(stringForm);
+    });
+
+    it("is byte-faithful when there is only a stable head", () => {
+      const builder = new PromptBuilder().registerMany([
+        { name: "a", priority: 100, stability: "static", render: () => "A" },
+        { name: "b", priority: 90, stability: "static", render: () => "B" },
+      ]);
+
+      const concatenated = builder
+        .buildSystemMessages({}, { cacheTtl: "5m" })
+        .map((m) => m.content)
+        .join("\n\n");
+
+      expect(concatenated).toBe(builder.build({}));
+    });
+  });
+
+  describe("buildWithDiagnostics consistency", () => {
+    it("the diagnostics fingerprint matches the concatenated system-message content", () => {
+      const builder = makeMixedBuilder();
+
+      const diagnostics = builder.buildWithDiagnostics({});
+      const concatenated = builder
+        .buildSystemMessages({}, { cacheTtl: "5m" })
+        .map((m) => m.content)
+        .join("\n\n");
+
+      expect(concatenated).toBe(diagnostics.prompt);
+    });
+
+    it("the boundary aligns with the first dynamic section in the diagnostics", () => {
+      const builder = makeMixedBuilder();
+
+      const diagnostics = builder.buildWithDiagnostics({});
+      const firstDynamicIndex = diagnostics.sections.findIndex((s) => s.stability === "dynamic");
+      const stableHeadContent = diagnostics.sections
+        .slice(0, firstDynamicIndex)
+        .map((s) => s.name)
+        .join(",");
+
+      // Head is exactly the leading run of static sections.
+      expect(stableHeadContent).toBe("identity,policy");
+
+      const messages = builder.buildSystemMessages({});
+      expect(messages[0]?.content).toBe("IDENTITY\n\nPOLICY");
+    });
+  });
+});


### PR DESCRIPTION
## What
Opt-in system-prompt cache breakpoint for LLE-10626. Adds `PromptBuilder.buildSystemMessages()` which emits `system` as `SystemModelMessage[]` split at the existing `stability` boundary, marking the stable head with Anthropic `providerOptions.anthropic.cacheControl` (ephemeral, `ttl` `5m`/`1h`); optional 2nd breakpoint at the latest turn; ≤4-breakpoint budget enforced.

Opt-in via `systemPromptCaching?: { enabled; ttl?; conversationBreakpoint? }` on `AgentOptions`, **default off** → current string `system` behaviour is byte-identical (proven by test). Provider-agnostic: only the `anthropic` namespace is set, inert for other providers (no model-sniffing). The pre-existing `providerOptions?: any` is untouched.

## Why
The deterministic alternative to relying on the Vercel AI Gateway `caching:'auto'` heuristic. lleverage will switch from gateway-auto to this explicit breakpoint after this cuts an RC + the pin is bumped — the two must not both be active.

## Tested
`bun run build` + `bun run type-check` clean; `bun run test` 2211 pass / 8 skip (24 new tests: boundary split, ttl, ≤4 budget, byte-identical-when-off, anthropic-only). Adversarially reviewed: SHIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in system-prompt caching for agents using a prompt builder, using a structured split between a “stable head” and “dynamic tail”.
  * Introduced `systemPromptCaching` with `cacheTtl` (default **5m**, supports **1h**).
  * Added optional conversation-prefix cache breakpoints to improve cache hit rates, capped by `MAX_PROMPT_CACHE_BREAKPOINTS` (**4**) and avoiding duplicate annotations.
  * Added `PromptBuilder.buildSystemMessages` plus related exports.
* **Tests**
  * Added coverage for system-message splitting, TTL overrides, breakpoint budgeting, and annotation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->