### PR TITLE
chore: release agent-sdk 0.1.0-alpha.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Parse release tag

--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Parse tag and extract package info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.9] - 2026-06-30
+
 ### Changed
 
 - **BREAKING**: Upgraded the AI SDK peer dependency from `ai@^6` to `ai@^7`. The

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lleverage-ai/agent-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "A TypeScript framework for building AI agents using the Vercel AI SDK v7",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release prep for **`@lleverage-ai/agent-sdk` 0.1.0-alpha.9** — the first version published after the AI SDK 7 upgrade + agent-threads consolidation + ledger-backed checkpointer (#149).

## Changes

- **Version bump**: `0.1.0-alpha.8 → 0.1.0-alpha.9` (`packages/agent-sdk/package.json`), continuing the established `alpha.N` cadence.
- **CHANGELOG**: moved the `[Unreleased]` entries into a dated `[0.1.0-alpha.9] - 2026-06-30` section (left a fresh empty `[Unreleased]` at the top). Covers the AI SDK 7 breaking changes, the agent-threads fold/removal, and the new `createLedgerCheckpointer`.
- **CI config**: bumped the `release` and `unpublish` workflows from Node 20 → 22 to match the new `engines: >=22` requirement.

## Notes on CI

The agent-threads removal in the CI workflows already landed in #149: `ci.yml` packs only `agent-sdk`, the dead `agent-threads@*` release trigger was removed, and `unpublish.yml` was restricted to the `agent-sdk@` tag prefix. No agent-threads references remain in `.github/workflows/`. This PR only adds the Node-version bump on top.

## Release

After merge, publishing is triggered by pushing the `agent-sdk@0.1.0-alpha.9` tag (handled by `release.yml`). Verified locally: `npm pack --dry-run` produces `@lleverage-ai/agent-sdk@0.1.0-alpha.9` with the full `dist` (including the `threads` subpaths). Build, type-check, lint, and the full test suite are green on `main`.

Refs: LLE-11082, LLE-10235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release version to **0.1.0-alpha.9** and added a new changelog entry.
  * Upgraded the release and unpublish workflow environments to **Node.js 22** for tagged release jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->