### PR TITLE
fix(context-manager): count tool-result outputs in the approximate token counter

### DIFF
--- a/packages/agent-sdk/src/context-manager.ts
+++ b/packages/agent-sdk/src/context-manager.ts
@@ -133,6 +133,18 @@ export function createApproximateTokenCounter(): TokenCounter {
       for (const part of message.content) {
         if ("text" in part && typeof part.text === "string") {
           total += count(part.text);
+        } else if ("result" in part || "output" in part) {
+          // Tool result - count output. Checked BEFORE the toolName branch:
+          // tool-result parts also carry `toolName`, so matching on toolName
+          // first counted a tool result as just its tool name and silently
+          // dropped the (usually dominant) output — undercounting tool-heavy
+          // transcripts ~4-5x and preventing compaction from ever triggering
+          // (LLE-11630).
+          const output = "result" in part ? part.result : part.output;
+          total += count(typeof output === "string" ? output : JSON.stringify(output));
+          if ("toolName" in part && typeof part.toolName === "string") {
+            total += count(part.toolName);
+          }
         } else if ("toolName" in part) {
           // Tool call - count name and args
           total += count(part.toolName);
@@ -142,10 +154,6 @@ export function createApproximateTokenCounter(): TokenCounter {
           if ("input" in part) {
             total += count(JSON.stringify(part.input));
           }
-        } else if ("result" in part || "output" in part) {
-          // Tool result - count output
-          const output = "result" in part ? part.result : part.output;
-          total += count(typeof output === "string" ? output : JSON.stringify(output));
         } else if ("image" in part) {
           // Image part - count ~1000 tokens for image (approximate vision model cost)
           // Images are expensive in terms of tokens, varies by size and model

--- a/packages/agent-sdk/tests/context-manager.test.ts
+++ b/packages/agent-sdk/tests/context-manager.test.ts
@@ -151,6 +151,46 @@ describe("createApproximateTokenCounter", () => {
       expect(tokens).toBeGreaterThan(4);
     });
 
+    it("should count tool-result outputs at their full size (LLE-11630 regression)", () => {
+      // Tool-result parts carry BOTH toolName and output. The counter used to
+      // match the toolName branch first and count a 50KB output as ~5 tokens,
+      // undercounting tool-heavy transcripts ~4-5x so compaction never fired.
+      const output = "x".repeat(50_000); // ~12.5K tokens at 4 chars/token
+      const messages: ModelMessage[] = [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "bash",
+              output: { type: "text", value: output },
+            },
+          ],
+        } as unknown as ModelMessage,
+      ];
+      const tokens = counter.countMessages(messages);
+      expect(tokens).toBeGreaterThan(12_000);
+    });
+
+    it("should count v4-shaped tool results carrying result alongside toolName", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "search",
+              result: { data: "y".repeat(4_000) },
+            },
+          ],
+        } as unknown as ModelMessage,
+      ];
+      const tokens = counter.countMessages(messages);
+      expect(tokens).toBeGreaterThan(1_000);
+    });
+
     it("should handle empty message array", () => {
       expect(counter.countMessages([])).toBe(0);
     });


### PR DESCRIPTION
# Count tool-result outputs in the approximate token counter

## Summary

`createApproximateTokenCounter#countSingleMessage` checks `"toolName" in part` before `"result" in part || "output" in part`. Tool-result parts carry **both** `toolName` and `output`, so they matched the tool-call branch and their output was never counted — a 50KB bash result counted as ~5 tokens.

On tool-heavy transcripts (the sessions that most need compaction) this undercounts the context estimate ~4-5x, so `shouldCompact`'s thresholds never trip and compaction never fires. This is the root cause behind Lleverage LLE-11630: measured against a real production checkpoint, tool results totalling ~881K tokens were counted as 1,647 tokens (535x undercount), and a session ran four days and ~$1,000 past the intended compaction boundary before triggering.

The fix reorders the branches: tool results (identified by `result`/`output`) are counted at their full serialised size (plus their tool name) before the `toolName` branch handles genuine tool calls.

## Verification

- New regression test: a tool-result part carrying both `toolName` and a 50KB `output` must count >12K tokens (previously ~6).
- New test for v4-shaped results (`result` field alongside `toolName`).
- Full `tests/context-manager.test.ts` suite: 58 pass, 0 fail.
- Full package test suite run via `bun test` after `bun run build`.

## Notes

- Lleverage's agent-service currently works around this via the `tokenCounter` injection point (lleverage-ai/lleverage#5843); once this ships in a release, that custom counter can be retired.
- The existing "should count tool results" test passed even with the bug because it only asserted `> 4` tokens — the new tests assert the output actually dominates the count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token estimation for tool-result messages by counting both result content and associated tool names.
  * Prevented large tool outputs from being significantly underestimated during token budgeting.
  * Improved reliability of context compaction for conversations containing tool calls and results.

* **Tests**
  * Added coverage for large tool outputs and different tool-result formats to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->